### PR TITLE
Add support for reading from files and stdin

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn ensure_correctness_of_regular_expressions() {
         for (input, expected_output) in params() {
-            assert_eq!(DFA::from(input).to_regex(), expected_output);
+            assert_eq!(DFA::from(input.iter().map(ToString::to_string).collect()).to_regex(), expected_output);
         }
     }
 

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -47,7 +47,7 @@ impl DFA {
         }
     }
 
-    pub fn from(strs: Vec<&str>) -> Self {
+    pub fn from(strs: Vec<String>) -> Self {
         let mut dfa = Self::new();
         for elem in strs {
             dfa.insert(elem);
@@ -56,9 +56,9 @@ impl DFA {
         dfa
     }
 
-    fn insert(&mut self, s: &str) {
+    fn insert(&mut self, s: String) {
         let mut current_state = self.initial_state;
-        for grapheme in UnicodeSegmentation::graphemes(s, true) {
+        for grapheme in UnicodeSegmentation::graphemes(s.as_str(), true) {
             self.alphabet.insert(grapheme.to_string());
             current_state = self.get_next_state(current_state, &grapheme);
         }


### PR DESCRIPTION
Addresses #1 

If no file is specified the program reads from `stdin`.
To read from a file the user can use the `-f [FILE]` or the long version `--file` 
Otherwise, the behavior is the same as before

Note: I had to change the signature of `DFA::from` and `DFA::insert` to get around ownership problems in `main`. It shouldn't affect the performance of the original version as no cloning is done either way.