### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -122,12 +122,12 @@ impl Expression {
         }
     }
 
-    fn value(&self, substring: &Option<&Substring>) -> Option<Vec<&str>> {
+    fn value(&self, substring: Option<&Substring>) -> Option<Vec<&str>> {
         match self {
             Expression::Concatenation(expr1, expr2) => match substring {
                 Some(value) => match value {
-                    Substring::Prefix => expr1.value(&None),
-                    Substring::Suffix => expr2.value(&None),
+                    Substring::Prefix => expr1.value(None),
+                    Substring::Suffix => expr2.value(None),
                 },
                 None => None,
             },
@@ -303,8 +303,8 @@ fn remove_common_substring(
 }
 
 fn find_common_substring(a: &Expression, b: &Expression, substring: &Substring) -> Option<String> {
-    let mut graphemes_a = a.value(&Some(substring)).unwrap_or_else(|| vec![]);
-    let mut graphemes_b = b.value(&Some(substring)).unwrap_or_else(|| vec![]);
+    let mut graphemes_a = a.value(Some(substring)).unwrap_or_else(|| vec![]);
+    let mut graphemes_b = b.value(Some(substring)).unwrap_or_else(|| vec![]);
     let mut common_graphemes = vec![];
 
     if let Substring::Suffix = substring {
@@ -489,24 +489,24 @@ mod tests {
     fn ensure_correct_removal_of_prefix_in_literal() {
         let mut literal = Expression::new_literal("abcdef");
         assert_eq!(
-            literal.value(&None),
+            literal.value(None),
             Some(vec!["a", "b", "c", "d", "e", "f"])
         );
 
         literal.remove_substring(&Substring::Prefix, 2);
-        assert_eq!(literal.value(&None), Some(vec!["c", "d", "e", "f"]));
+        assert_eq!(literal.value(None), Some(vec!["c", "d", "e", "f"]));
     }
 
     #[test]
     fn ensure_correct_removal_of_suffix_in_literal() {
         let mut literal = Expression::new_literal("abcdef");
         assert_eq!(
-            literal.value(&None),
+            literal.value(None),
             Some(vec!["a", "b", "c", "d", "e", "f"])
         );
 
         literal.remove_substring(&Substring::Suffix, 2);
-        assert_eq!(literal.value(&None), Some(vec!["a", "b", "c", "d"]));
+        assert_eq!(literal.value(None), Some(vec!["a", "b", "c", "d"]));
     }
 
     #[test]

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -109,7 +109,7 @@ impl DFA {
                 while let Some(y) = p_cursor.peek_next() {
                     let i = x
                         .intersection(y)
-                        .map(|elem| *elem)
+                        .copied()
                         .collect::<LinkedHashSet<State>>();
 
                     if i.is_empty() {
@@ -119,7 +119,7 @@ impl DFA {
 
                     let d = y
                         .difference(&x)
-                        .map(|elem| *elem)
+                        .copied()
                         .collect::<LinkedHashSet<State>>();
 
                     if d.is_empty() {
@@ -197,7 +197,7 @@ impl DFA {
 
         for equivalence_class in p.iter() {
             let old_source_state = *equivalence_class.iter().next().unwrap();
-            let new_source_state = self.get_target_state(&graph, &old_source_state);
+            let new_source_state = self.get_target_state(&graph, old_source_state);
 
             for old_target_state in self.graph.neighbors(old_source_state) {
                 let edge = self
@@ -206,7 +206,7 @@ impl DFA {
                     .unwrap();
 
                 let edge_label = self.graph.edge_weight(edge).unwrap();
-                let new_target_state = self.get_target_state(&graph, &old_target_state);
+                let new_target_state = self.get_target_state(&graph, old_target_state);
 
                 graph.add_edge(new_source_state, new_target_state, edge_label.clone());
 
@@ -223,7 +223,7 @@ impl DFA {
     fn get_target_state(
         &self,
         graph: &StableGraph<HashSet<usize>, String>,
-        source_state: &State,
+        source_state: State,
     ) -> State {
         graph
             .node_indices()
@@ -243,7 +243,7 @@ impl DFA {
             .unwrap()
     }
 
-    fn is_final_state(&self, state: &State) -> bool {
+    fn is_final_state(&self, state: State) -> bool {
         self.final_state_indices.contains(&state.index())
     }
 
@@ -261,7 +261,7 @@ impl DFA {
         }
 
         for (i, state) in states.iter().enumerate() {
-            if self.is_final_state(state) {
+            if self.is_final_state(*state) {
                 b[i] = Some(Expression::new_literal(""));
             }
 


### PR DESCRIPTION
Fixed warnings about pass by ref/value, and verbose map copy.

To show these warnings:

```sh
$ rustup component add clippy
$ cargo clippy # at root of grex repo
```

Edit: you might need to `cargo clean -p grex` to see the warnings with `cargo clippy`. There are some warnings left, but they relate to variable naming, which might be a personal preference :)