### PR TITLE
Add option to exclude test cases

### DIFF
--- a/src/char/mod.rs
+++ b/src/char/mod.rs
@@ -21,3 +21,4 @@ mod grapheme;
 pub use cluster::GraphemeCluster;
 pub use color::ColorizableString;
 pub use grapheme::Grapheme;
+pub(crate) use grapheme::GraphemeOverlapState;

--- a/src/fsm/dfa.rs
+++ b/src/fsm/dfa.rs
@@ -14,27 +14,54 @@
  * limitations under the License.
  */
 
-use crate::char::{Grapheme, GraphemeCluster};
+use crate::char::{Grapheme, GraphemeCluster, GraphemeOverlapState};
 use crate::regexp::RegExpConfig;
 use itertools::Itertools;
-use petgraph::dot::{Config, Dot};
+use petgraph::dot::Dot;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::{Edges, StableGraph};
-use petgraph::visit::Dfs;
+use petgraph::visit::{Dfs, EdgeRef, NodeIndexable};
 use petgraph::{Directed, Direction};
-use std::cmp::{max, min};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::cmp::max;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::fmt::{Display, Formatter, Result};
 
 type State = NodeIndex<u32>;
-type StateLabel = String;
 type EdgeLabel = Grapheme;
 
+#[derive(PartialEq, Clone, Debug, Copy)]
+enum StateStatus {
+    Intermediate,
+    Accept,
+}
+
+#[derive(Clone)]
+struct StateLabel {
+    description: String,
+    status: StateStatus,
+}
+
+#[derive(Clone)]
 pub struct DFA {
     alphabet: BTreeSet<Grapheme>,
     graph: StableGraph<StateLabel, EdgeLabel>,
     initial_state: State,
-    final_state_indices: HashSet<usize>,
     config: RegExpConfig,
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+enum InputState<T> {
+    Both(T, T),
+    Left(T),
+}
+
+struct DFASubtractionBuilder<'a> {
+    left: &'a DFA,
+    right: &'a DFA,
+    result: DFA,
+    new_nodes: HashMap<InputState<usize>, State>,
+    queue: VecDeque<InputState<usize>>,
+    enqueued: HashSet<InputState<usize>>,
 }
 
 impl DFA {
@@ -65,27 +92,28 @@ impl DFA {
     }
 
     pub(crate) fn is_final_state(&self, state: State) -> bool {
-        self.final_state_indices.contains(&state.index())
+        self.graph[state].status == StateStatus::Accept
+    }
+
+    pub(crate) fn subtract(&self, other: &Self) -> Option<Self> {
+        DFASubtractionBuilder::subtract(self, other)
     }
 
     #[allow(dead_code)]
     fn println(&self, comment: &str) {
-        println!(
-            "{}: {}",
-            comment,
-            Dot::with_config(&self.graph, &[Config::NodeIndexLabel])
-        );
-        println!("{:?}", self.final_state_indices);
+        println!("{}: {}", comment, Dot::new(&self.graph));
     }
 
     fn new(config: &RegExpConfig) -> Self {
         let mut graph = StableGraph::new();
-        let initial_state = graph.add_node("".to_string());
+        let initial_state = graph.add_node(StateLabel {
+            description: "initial".to_string(),
+            status: StateStatus::Intermediate,
+        });
         Self {
             alphabet: BTreeSet::new(),
             graph,
             initial_state,
-            final_state_indices: HashSet::new(),
             config: config.clone(),
         }
     }
@@ -97,48 +125,68 @@ impl DFA {
             self.alphabet.insert(grapheme.clone());
             current_state = self.get_next_state(current_state, grapheme);
         }
-        self.final_state_indices.insert(current_state.index());
+        self.graph[current_state].status = StateStatus::Accept;
     }
 
     fn get_next_state(&mut self, current_state: State, edge_label: &Grapheme) -> State {
-        match self.find_next_state(current_state, edge_label) {
-            Some(next_state) => next_state,
+        match self
+            .graph
+            .edges_directed(current_state, Direction::Outgoing)
+            .find(|edge| *edge.weight() == *edge_label)
+        {
+            Some(edge) => edge.target(),
             None => self.add_new_state(current_state, edge_label),
         }
     }
 
-    fn find_next_state(&mut self, current_state: State, grapheme: &Grapheme) -> Option<State> {
-        for next_state in self.graph.neighbors(current_state) {
-            let edge_idx = self.graph.find_edge(current_state, next_state).unwrap();
-            let current_grapheme = self.graph.edge_weight(edge_idx).unwrap();
-
-            if current_grapheme.value() != grapheme.value() {
-                continue;
-            }
-
-            if current_grapheme.maximum() == grapheme.maximum() - 1 {
-                let min = min(current_grapheme.minimum(), grapheme.minimum());
-                let max = max(current_grapheme.maximum(), grapheme.maximum());
-                let new_grapheme = Grapheme::new(grapheme.chars().clone(), min, max, &self.config);
-                self.graph
-                    .update_edge(current_state, next_state, new_grapheme);
-                return Some(next_state);
-            } else if current_grapheme.maximum() == grapheme.maximum() {
-                return Some(next_state);
-            }
-        }
-        None
-    }
-
     fn add_new_state(&mut self, current_state: State, edge_label: &Grapheme) -> State {
-        let next_state = self.graph.add_node("".to_string());
+        let next_state = self.graph.add_node(StateLabel {
+            description: "".to_string(),
+            status: StateStatus::Intermediate,
+        });
         self.graph
             .add_edge(current_state, next_state, edge_label.clone());
         next_state
     }
 
-    #[allow(clippy::many_single_char_names)]
     fn minimize(&mut self) {
+        self.remove_dead_ends();
+        self.deduplicate_equivalent_states();
+        self.deduplicate_redundant_edges();
+    }
+
+    pub fn remove_dead_ends(&mut self) {
+        let mut queue: VecDeque<State> = self.graph.node_indices().collect();
+        let initial_size = self.graph.node_count();
+
+        while let Some(state) = queue.pop_front() {
+            if !self.graph.contains_node(state) || state.index() == self.initial_state.index() {
+                continue;
+            }
+
+            let has_outgoing = self.graph.edges_directed(state, Direction::Outgoing).next() != None;
+            let has_incoming = self.graph.edges_directed(state, Direction::Incoming).next() != None;
+            let is_final = self.graph[state].status == StateStatus::Accept;
+
+            if (has_outgoing || is_final) && has_incoming {
+                continue;
+            }
+
+            queue.append(&mut self.graph.neighbors(state).collect());
+            self.graph.remove_node(state);
+        }
+
+        if self.graph.node_count() != initial_size {
+            self.alphabet = self
+                .graph
+                .edge_indices()
+                .map(|e| self.graph[e].clone())
+                .collect();
+        }
+    }
+
+    #[allow(clippy::many_single_char_names)]
+    fn deduplicate_equivalent_states(&mut self) {
         let mut p = self.get_initial_partition();
         let mut w = p.iter().cloned().collect_vec();
 
@@ -196,13 +244,74 @@ impl DFA {
         self.recreate_graph(p.iter().filter(|&it| !it.is_empty()).collect_vec());
     }
 
+    fn deduplicate_redundant_edges(&mut self) {
+        for state in self.graph.node_indices().collect_vec() {
+            let mut next_nodes = HashMap::new();
+            for edge in self.graph.edges_directed(state, Direction::Outgoing) {
+                next_nodes
+                    .entry(edge.target().index())
+                    .or_insert_with(HashMap::new)
+                    .entry(edge.weight().value())
+                    .or_insert_with(Vec::new)
+                    .push(edge.id());
+            }
+
+            for (next_index, mut grapheme_map) in next_nodes {
+                for edges in grapheme_map.values_mut() {
+                    let graphemes = edges
+                        .iter()
+                        .map(|edge| self.graph[*edge].clone())
+                        .collect_vec();
+                    let new_graphemes = self.merge_graphemes(graphemes);
+                    if new_graphemes.len() == edges.len() {
+                        continue;
+                    }
+                    for edge in edges {
+                        self.graph.remove_edge(*edge);
+                    }
+                    for grapheme in new_graphemes.iter().rev() {
+                        self.graph.add_edge(
+                            state,
+                            self.graph.from_index(next_index),
+                            grapheme.clone(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn merge_graphemes(&self, mut graphemes: Vec<Grapheme>) -> Vec<Grapheme> {
+        graphemes.sort_by_key(|grapheme| (grapheme.minimum(), grapheme.maximum()));
+
+        let mut result = Vec::new();
+        for grapheme in graphemes {
+            match result.last_mut() {
+                None => result.push(grapheme),
+                Some(last) => {
+                    if last.maximum() + 1 >= grapheme.minimum() {
+                        *last = Grapheme::new(
+                            last.chars().clone(),
+                            last.minimum(),
+                            max(last.maximum(), grapheme.maximum()),
+                            &self.config,
+                        );
+                    } else {
+                        result.push(grapheme);
+                    }
+                }
+            }
+        }
+        result
+    }
+
     fn get_initial_partition(&self) -> Vec<HashSet<State>> {
         let (final_states, non_final_states): (HashSet<State>, HashSet<State>) = self
             .graph
             .node_indices()
-            .partition(|&state| !self.final_state_indices.contains(&state.index()));
+            .partition(|&state| self.graph[state].status != StateStatus::Intermediate);
 
-        vec![final_states, non_final_states]
+        vec![non_final_states, final_states]
     }
 
     fn get_parent_states(&self, a: &HashSet<State>, label: &Grapheme) -> HashSet<State> {
@@ -225,46 +334,241 @@ impl DFA {
         x
     }
 
-    fn recreate_graph(&mut self, p: Vec<&HashSet<State>>) {
+    fn recreate_graph(&mut self, equivalence_classes: Vec<&HashSet<State>>) {
         let mut graph = StableGraph::<StateLabel, EdgeLabel>::new();
-        let mut final_state_indices = HashSet::new();
         let mut state_mappings = HashMap::new();
         let mut new_initial_state: Option<NodeIndex> = None;
 
-        for equivalence_class in p.iter() {
-            let new_state = graph.add_node("".to_string());
+        for equivalence_class in equivalence_classes.iter() {
+            let new_state = graph.add_node(StateLabel {
+                description: format!(
+                    "{:?}",
+                    equivalence_class
+                        .iter()
+                        .map(|state| state.index())
+                        .collect_vec()
+                ),
+                status: self.graph[*equivalence_class.iter().next().unwrap()].status,
+            });
 
             for old_state in equivalence_class.iter() {
                 if self.initial_state == *old_state {
                     new_initial_state = Some(new_state);
+                    graph[new_state].description.push_str(" initial");
                 }
                 state_mappings.insert(*old_state, new_state);
             }
         }
 
-        for equivalence_class in p.iter() {
-            let old_source_state = *equivalence_class.iter().next().unwrap();
-            let new_source_state = state_mappings.get(&old_source_state).unwrap();
+        for equivalence_class in equivalence_classes.iter() {
+            let new_source_state = state_mappings
+                .get(equivalence_class.iter().next().unwrap())
+                .unwrap();
 
-            for old_target_state in self.graph.neighbors(old_source_state) {
-                let edge = self
-                    .graph
-                    .find_edge(old_source_state, old_target_state)
-                    .unwrap();
+            let mut added_edges: HashSet<(Grapheme, usize)> = HashSet::new();
 
-                let grapheme = self.graph.edge_weight(edge).unwrap().clone();
-                let new_target_state = state_mappings.get(&old_target_state).unwrap();
+            for edge in equivalence_class
+                .iter()
+                .flat_map(|from_state| self.graph.edges_directed(*from_state, Direction::Outgoing))
+            {
+                let grapheme = edge.weight();
+                let new_target_state = state_mappings.get(&edge.target()).unwrap();
 
-                graph.add_edge(*new_source_state, *new_target_state, grapheme.clone());
-
-                if self.final_state_indices.contains(&old_target_state.index()) {
-                    final_state_indices.insert(new_target_state.index());
+                if added_edges.insert((grapheme.clone(), new_target_state.index())) {
+                    graph.add_edge(*new_source_state, *new_target_state, grapheme.clone());
                 }
             }
         }
         self.initial_state = new_initial_state.unwrap();
-        self.final_state_indices = final_state_indices;
         self.graph = graph;
+    }
+}
+
+impl Display for StateLabel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{} ({:?})", self.description, self.status)
+    }
+}
+
+impl<T> InputState<T> {
+    fn map_any<R, F, G>(&self, f: F, g: G) -> InputState<R>
+    where
+        F: FnOnce(&T) -> R,
+        G: FnOnce(&T) -> R,
+    {
+        match self {
+            Self::Left(x) => InputState::Left(f(x)),
+            Self::Both(x, y) => InputState::Both(f(x), g(y)),
+        }
+    }
+}
+
+impl<'a> DFASubtractionBuilder<'a> {
+    fn subtract(left: &'a DFA, right: &'a DFA) -> Option<DFA> {
+        if left.config != right.config {
+            None
+        } else {
+            let mut builder = Self {
+                left,
+                right,
+                result: DFA::new(&left.config),
+                new_nodes: HashMap::new(),
+                queue: VecDeque::new(),
+                enqueued: HashSet::new(),
+            };
+            builder.build();
+            Some(builder.result)
+        }
+    }
+
+    fn output_state_status(&self, idx: InputState<usize>) -> StateStatus {
+        match idx.map_any(
+            |state_left| self.left.graph[self.left.graph.from_index(*state_left)].status,
+            |state_right| self.right.graph[self.right.graph.from_index(*state_right)].status,
+        ) {
+            InputState::Both(_, StateStatus::Accept) => StateStatus::Intermediate,
+            InputState::Both(StateStatus::Accept, _) => StateStatus::Accept,
+            InputState::Left(StateStatus::Accept) => StateStatus::Accept,
+            _ => StateStatus::Intermediate,
+        }
+    }
+
+    fn input_to_output_state_space(&mut self, idx: &InputState<usize>) -> State {
+        if *idx
+            == InputState::Both(
+                self.left.initial_state.index(),
+                self.right.initial_state.index(),
+            )
+        {
+            self.result.initial_state
+        } else {
+            match self.new_nodes.get(&idx) {
+                Some(state) => *state,
+                None => {
+                    let new_state = self.result.graph.add_node(StateLabel {
+                        description: format!("{:?}", idx),
+                        status: self.output_state_status(idx.clone()),
+                    });
+                    self.new_nodes.insert(idx.clone(), new_state);
+                    new_state
+                }
+            }
+        }
+    }
+
+    fn add_edge(&mut self, new_from: State, grapheme: Grapheme, input: &InputState<usize>) {
+        let new_to = self.input_to_output_state_space(input);
+        self.result.graph.add_edge(new_from, new_to, grapheme);
+        if !self.enqueued.contains(&input) {
+            self.queue.push_back(input.clone());
+            self.enqueued.insert(input.clone());
+        }
+    }
+
+    fn overlap_all_grapheme(
+        &mut self,
+        left: Grapheme,
+        rights: Vec<(Grapheme, usize)>,
+    ) -> (Vec<Grapheme>, Vec<(Grapheme, usize)>) {
+        let mut overlaps = Vec::new();
+        let mut unoverlapped = vec![left];
+
+        for (right_grapheme, right_idx) in rights {
+            let mut new_unoverlapped = Vec::new();
+            for left_grapheme in unoverlapped {
+                for (new_grapheme, overlap_state) in
+                    left_grapheme.overlap_with(&right_grapheme).unwrap()
+                {
+                    match overlap_state {
+                        GraphemeOverlapState::Right => continue,
+                        GraphemeOverlapState::Overlap => overlaps.push((new_grapheme, right_idx)),
+                        GraphemeOverlapState::Left => new_unoverlapped.push(new_grapheme),
+                    }
+                }
+            }
+            unoverlapped = new_unoverlapped;
+        }
+        (unoverlapped, overlaps)
+    }
+
+    fn build(&mut self) {
+        let input_initial = InputState::Both(
+            self.left.initial_state.index(),
+            self.right.initial_state.index(),
+        );
+        self.queue.push_back(input_initial.clone());
+        self.enqueued.insert(input_initial);
+
+        while let Some(idx) = self.queue.pop_front() {
+            let new_from = self.input_to_output_state_space(&idx);
+
+            match idx.map_any(
+                |left_idx| {
+                    self.left
+                        .outgoing_edges(self.left.graph.from_index(*left_idx))
+                },
+                |right_idx| {
+                    self.right
+                        .outgoing_edges(self.right.graph.from_index(*right_idx))
+                },
+            ) {
+                InputState::Left(left_edges) => {
+                    for edge in left_edges {
+                        self.add_edge(
+                            new_from,
+                            edge.weight().clone(),
+                            &InputState::Left(edge.target().index()),
+                        );
+                    }
+                }
+                InputState::Both(left_edges, right_edges) => {
+                    let right_edges_vec = right_edges.collect_vec();
+
+                    for edge_left in left_edges {
+                        let grapheme_left = edge_left.weight();
+                        let edge_left_to = edge_left.target().index();
+
+                        let matching_edges = right_edges_vec
+                            .iter()
+                            .filter(|edge| edge.weight().value() == grapheme_left.value())
+                            .collect_vec();
+
+                        let (unoverlapped, overlapped) = self.overlap_all_grapheme(
+                            grapheme_left.clone(),
+                            matching_edges
+                                .iter()
+                                .map(|edge| (edge.weight().clone(), edge.target().index()))
+                                .collect_vec(),
+                        );
+
+                        for new_grapheme in unoverlapped {
+                            self.add_edge(
+                                new_from,
+                                new_grapheme.clone(),
+                                &InputState::Left(edge_left_to),
+                            );
+                        }
+
+                        for (new_grapheme, edge_right_to) in overlapped {
+                            self.add_edge(
+                                new_from,
+                                new_grapheme.clone(),
+                                &InputState::Both(edge_left_to, edge_right_to),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        self.result.alphabet = self
+            .result
+            .graph
+            .edge_indices()
+            .map(|e| self.result.graph[e].clone())
+            .collect();
+
+        self.result.minimize();
     }
 }
 
@@ -295,6 +599,28 @@ mod tests {
 
         let final_state = State::new(4);
         assert_eq!(dfa.is_final_state(final_state), true);
+    }
+
+    #[test]
+    fn test_subtraction() {
+        let config = RegExpConfig::new();
+        let dfa1 = DFA::from(
+            vec![
+                GraphemeCluster::from("abcd", &RegExpConfig::new()),
+                GraphemeCluster::from("abcf", &RegExpConfig::new()),
+            ],
+            &config,
+        );
+        let dfa2 = DFA::from(
+            vec![GraphemeCluster::from("abcd", &RegExpConfig::new())],
+            &config,
+        );
+
+        let dfa_option = dfa1.subtract(&dfa2);
+        assert!(dfa_option.is_some());
+
+        let dfa = dfa_option.unwrap();
+        assert_eq!(dfa.state_count(), 5);
     }
 
     #[test]

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -83,7 +83,7 @@ mod no_conversion {
             grex.args(&["-f", file.path().to_str().unwrap()]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^(?:b\\\\n|äöü|[ac♥])$\n"));
+                .stdout(predicate::eq("^(?:b\\\\n|äöü|[ac♥])?$\n"));
         }
 
         #[test]
@@ -120,7 +120,7 @@ mod no_conversion {
                 .success()
                 .stdout(predicate::str::is_empty())
                 .stderr(predicate::eq(
-                    "error: the specified file could not be found\n",
+                    "error: the specified input file could not be found\n",
                 ));
         }
 

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -160,6 +160,31 @@ proptest! {
 
     #[test]
     #[ignore]
+    fn regexes_not_matching_other_strings_with_default_settings_restricted_alphabet(
+        test_cases in prop::collection::hash_set("[a-f]{1,10}", 1..=10),
+        other_strings in prop::collection::hash_set("[a-f]{1,10}", 1..=100)
+    ) {
+        let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
+        let regexp = RegExpBuilder::from(&test_cases_vec).build();
+        let compiled_regexp = compile_regexp(&regexp).unwrap();
+        prop_assert!(other_strings.iter().filter(|other_string| !test_cases_vec.contains(other_string)).all(|other_string| !compiled_regexp.is_match(&other_string)));
+    }
+
+
+    #[test]
+    #[ignore]
+    fn regexes_not_matching_other_strings_with_repetition_restricted_alphabet(
+        test_cases in prop::collection::hash_set("[a-f]{1,10}", 1..=10),
+        other_strings in prop::collection::hash_set("[a-f]{1,10}", 1..=100)
+    ) {
+        let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
+        let regexp = RegExpBuilder::from(&test_cases_vec).with_conversion_of(&[Feature::Repetition]).build();
+        let compiled_regexp = compile_regexp(&regexp).unwrap();
+        prop_assert!(other_strings.iter().filter(|other_string| !test_cases_vec.contains(other_string)).all(|other_string| !compiled_regexp.is_match(&other_string)));
+    }
+
+    #[test]
+    #[ignore]
     fn regexes_not_matching_other_strings_with_escape_sequences(
         test_cases in prop::collection::hash_set(".{1,20}", 1..=10),
         other_strings in prop::collection::hash_set(".{1,20}", 1..=10)
@@ -171,6 +196,48 @@ proptest! {
                 .build();
             if let Ok(compiled_regexp) = compile_regexp(&regexp) {
                 prop_assert!(other_strings.iter().all(|other_string| !compiled_regexp.is_match(&other_string)));
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn regexes_not_matching_negative_test_cases(
+        test_cases in prop::collection::hash_set("[a-f]{1,20}", 1..=10),
+        negative_test_cases in prop::collection::hash_set("[a-f]{1,20}", 1..=10)
+    ) {
+        let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
+        let negative_test_cases_vec = negative_test_cases.iter().cloned().collect::<Vec<_>>();
+        let regexp = RegExpBuilder::from(&test_cases_vec)
+            .with_negative_matches(&negative_test_cases_vec)
+            .build();
+        let compiled_regexp = compile_regexp(&regexp).unwrap();
+        for test_case in negative_test_cases {
+            prop_assert_eq!(compiled_regexp.is_match(&test_case), false, "Negative test case \"{}\" matched regex \"{}\"", test_case, regexp);
+        }
+        for test_case in test_cases.iter().filter(|test_case| !negative_test_cases_vec.contains(&test_case)) {
+            prop_assert_eq!(compiled_regexp.is_match(&test_case), true, "Positive test case \"{}\" didn't match regex \"{}\"", test_case, regexp);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn regexes_not_matching_negative_test_cases_with_repetition(
+        test_cases in prop::collection::hash_set("[a-f]{1,20}", 1..=10),
+        negative_test_cases in prop::collection::hash_set("[a-f]{1,20}", 1..=10)
+    ) {
+        let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
+        let negative_test_cases_vec = negative_test_cases.iter().cloned().collect::<Vec<_>>();
+        let regexp = RegExpBuilder::from(&test_cases_vec)
+            .with_negative_matches(&negative_test_cases_vec)
+            .with_conversion_of(&[Feature::Repetition])
+            .build();
+        if let Ok(compiled_regexp) = compile_regexp(&regexp) {
+            for test_case in negative_test_cases {
+                prop_assert_eq!(compiled_regexp.is_match(&test_case), false, "Negative test case \"{}\" matched regex \"{}\"", test_case, regexp);
+            }
+            for test_case in test_cases.iter().filter(|test_case| !negative_test_cases_vec.contains(&test_case)) {
+                prop_assert_eq!(compiled_regexp.is_match(&test_case), true, "Positive test case \"{}\" didn't matched regex \"{}\"", test_case, regexp);
             }
         }
     }


### PR DESCRIPTION
This adds a new option `--file-negative`, which contains a list of negative test cases. The resulting regex will strictly not matching any of these test cases. This fixes #16.

----

To support negation, a second DFA is built of the negative cases, and then subtracted from the positive case DFA, using the [standard DFA combination algorithm](https://stackoverflow.com/a/7798776/315936). To limit the number of nodes generated, combinations of nodes in the two DFAs are visited in depth-first order. Nodes that only occur in the negative match DFA are not visited.

Because the repetition feature can produce grapheme transitions in the DFA that are variable length, code is added to calculate the overlap of two grapheme ranges.

The generated graphs can contain 'dead ends' so some code is added to remove those. Some bug fixes for corner cases that were previously not hit were needed in the `recreate_graph` function were also necessary. Also `find_next_state` was written to use the new grapheme overlapping function, to prevent sometimes creating multiple conflicting edges out of a node.

As part of this, a bug was fixed that previously caused blank lines the input to not be considered in the final regex, because the "initial" state could never be considered an accept state.

I got rid of `final_state_indices` and moved that information into the node label. I also added descriptive labels to nodes to aid debugging.

Adds appropriate tests. All pass. Ran through `cargo fmt` and `cargo clippy`.

I haven't written much rust before so please let me know if there are any issues.