### PR TITLE
Make anchors "^" and "$" optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! use grex::RegExpBuilder;
 //!
 //! let regexp = RegExpBuilder::from(&["a", "aa", "aaa"]).build();
-//! assert_eq!(regexp, "^a(?:aa?)?$");
+//! assert_eq!(regexp, "a(?:aa?)?");
 //! ```
 //!
 //! ### 4.2 Convert to character classes
@@ -104,7 +104,7 @@
 //! let regexp = RegExpBuilder::from(&["a", "aa", "123"])
 //!     .with_conversion_of(&[Feature::Digit, Feature::Word])
 //!     .build();
-//! assert_eq!(regexp, "^(?:\\d\\d\\d|\\w(?:\\w)?)$");
+//! assert_eq!(regexp, "(?:\\d\\d\\d|\\w(?:\\w)?)");
 //! ```
 //!
 //! ### 4.3 Convert repeated substrings
@@ -115,7 +115,7 @@
 //! let regexp = RegExpBuilder::from(&["aa", "bcbc", "defdefdef"])
 //!     .with_conversion_of(&[Feature::Repetition])
 //!     .build();
-//! assert_eq!(regexp, "^(?:a{2}|(?:bc){2}|(?:def){3})$");
+//! assert_eq!(regexp, "(?:a{2}|(?:bc){2}|(?:def){3})");
 //! ```
 //!
 //! By default, *grex* converts each substring this way which is at least a single character long
@@ -132,7 +132,7 @@
 //!     .with_conversion_of(&[Feature::Repetition])
 //!     .with_minimum_substring_length(2)
 //!     .build();
-//! assert_eq!(regexp, "^(?:aa|(?:bc){2}|(?:def){3})$");
+//! assert_eq!(regexp, "(?:aa|(?:bc){2}|(?:def){3})");
 //! ```
 //!
 //! Setting a minimum number of 2 repetitions in the next example, only the test case `defdefdef`
@@ -145,7 +145,7 @@
 //!     .with_conversion_of(&[Feature::Repetition])
 //!     .with_minimum_repetitions(2)
 //!     .build();
-//! assert_eq!(regexp, "^(?:bcbc|aa|(?:def){3})$");
+//! assert_eq!(regexp, "(?:bcbc|aa|(?:def){3})");
 //! ```
 //!
 //! ### 4.4 Escape non-ascii characters
@@ -156,7 +156,7 @@
 //! let regexp = RegExpBuilder::from(&["You smell like 💩."])
 //!     .with_escaping_of_non_ascii_chars(false)
 //!     .build();
-//! assert_eq!(regexp, "^You smell like \\u{1f4a9}\\.$");
+//! assert_eq!(regexp, "You smell like \\u{1f4a9}\\.");
 //! ```
 //!
 //! Old versions of JavaScript do not support unicode escape sequences for
@@ -171,7 +171,7 @@
 //! let regexp = RegExpBuilder::from(&["You smell like 💩."])
 //!     .with_escaping_of_non_ascii_chars(true)
 //!     .build();
-//! assert_eq!(regexp, "^You smell like \\u{d83d}\\u{dca9}\\.$");
+//! assert_eq!(regexp, "You smell like \\u{d83d}\\u{dca9}\\.");
 //! ```
 //!
 //! ### 4.5 Case-insensitive matching
@@ -185,7 +185,7 @@
 //! let regexp = RegExpBuilder::from(&["big", "BIGGER"])
 //!     .with_conversion_of(&[Feature::CaseInsensitivity])
 //!     .build();
-//! assert_eq!(regexp, "(?i)^big(?:ger)?$");
+//! assert_eq!(regexp, "(?i)big(?:ger)?");
 //! ```
 //!
 //! ### 4.6 Capturing Groups
@@ -199,7 +199,7 @@
 //! let regexp = RegExpBuilder::from(&["big", "BIGGER"])
 //!     .with_conversion_of(&[Feature::CaseInsensitivity, Feature::CapturingGroup])
 //!     .build();
-//! assert_eq!(regexp, "(?i)^big(ger)?$");
+//! assert_eq!(regexp, "(?i)big(ger)?");
 //! ```
 //!
 //! ### 4.7 Verbose mode
@@ -218,16 +218,14 @@
 //! assert_eq!(regexp, indoc!(
 //!     r#"
 //!     (?x)
-//!     ^
+//!     (?:
+//!       b
 //!       (?:
-//!         b
-//!         (?:
-//!           cd
-//!         )?
-//!         |
-//!         a
-//!       )
-//!     $"#
+//!         cd
+//!       )?
+//!       |
+//!       a
+//!     )"#
 //! ));
 //! ```
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,33 @@ struct Cli {
     )]
     is_output_colorized: bool,
 
+    #[structopt(
+        name = "match-beginning",
+        short = "B",
+        long,
+        help = "Match the beginning of the string (prepend \"^\")",
+        display_order = 14
+    )]
+    is_match_begin: bool,
+
+    #[structopt(
+        name = "match-end",
+        short = "E",
+        long,
+        help = "Match the end of the string (append \"$\")",
+        display_order = 15
+    )]
+    is_match_end: bool,
+
+    #[structopt(
+        name = "match-line",
+        short = "X",
+        long,
+        help = "Match the whole string (as a shorthand for -B -E)",
+        display_order = 16
+    )]
+    is_match_line: bool,
+
     // --------------------
     // OPTIONS
     // --------------------
@@ -310,6 +337,9 @@ fn handle_input(cli: &Cli, input: Result<Vec<String>, Error>) {
             }
 
             builder
+                .with_line_borders(
+                      cli.is_match_begin || cli.is_match_line
+                    , cli.is_match_end   || cli.is_match_line)
                 .with_minimum_repetitions(cli.minimum_repetitions)
                 .with_minimum_substring_length(cli.minimum_substring_length);
 

--- a/src/regexp/builder.rs
+++ b/src/regexp/builder.rs
@@ -154,17 +154,6 @@ impl RegExpBuilder {
     /// Every generated regular expression is surrounded by the anchors `^` and `$`
     /// so that substrings not being part of the test cases are not matched accidentally.
     pub fn build(&mut self) -> String {
-        let mut s = RegExp::from(&mut self.test_cases, &self.config).to_string();
-        if !self.config.is_match_begin {
-            if let Some(p) = s.find("^") {
-                s.remove(p);
-            }
-        }
-        if !self.config.is_match_end {
-            if let Some(p) = s.rfind("$") {
-                s.remove(p);
-            }
-        }
-        s
+        RegExp::from(&mut self.test_cases, &self.config).to_string()
     }
 }

--- a/src/regexp/builder.rs
+++ b/src/regexp/builder.rs
@@ -143,10 +143,28 @@ impl RegExpBuilder {
         self
     }
 
+    /// Tells `RegExpBuilder` to concatenate the resulting regular expression with the "^" and "$" anchors.
+    pub fn with_line_borders(&mut self, match_begin: bool, match_end: bool) -> &mut Self {
+        self.config.is_match_begin = match_begin;
+        self.config.is_match_end   = match_end;
+        self
+    }
+
     /// Builds the actual regular expression using the previously given settings.
     /// Every generated regular expression is surrounded by the anchors `^` and `$`
     /// so that substrings not being part of the test cases are not matched accidentally.
     pub fn build(&mut self) -> String {
-        RegExp::from(&mut self.test_cases, &self.config).to_string()
+        let mut s = RegExp::from(&mut self.test_cases, &self.config).to_string();
+        if !self.config.is_match_begin {
+            if let Some(p) = s.find("^") {
+                s.remove(p);
+            }
+        }
+        if !self.config.is_match_end {
+            if let Some(p) = s.rfind("$") {
+                s.remove(p);
+            }
+        }
+        s
     }
 }

--- a/src/regexp/config.rs
+++ b/src/regexp/config.rs
@@ -25,6 +25,8 @@ pub struct RegExpConfig {
     pub(crate) is_astral_code_point_converted_to_surrogate: bool,
     pub(crate) is_verbose_mode_enabled: bool,
     pub(crate) is_output_colorized: bool,
+    pub(crate) is_match_begin: bool,
+    pub(crate) is_match_end: bool,
 }
 
 impl RegExpConfig {
@@ -37,6 +39,8 @@ impl RegExpConfig {
             is_astral_code_point_converted_to_surrogate: false,
             is_verbose_mode_enabled: false,
             is_output_colorized: false,
+            is_match_begin: false,
+            is_match_end: false,
         }
     }
 

--- a/src/regexp/regexp.rs
+++ b/src/regexp/regexp.rs
@@ -87,8 +87,16 @@ impl Display for RegExp {
         } else {
             String::new()
         };
-        let caret = Component::Caret.to_repr(self.config.is_output_colorized);
-        let dollar_sign = Component::DollarSign.to_repr(self.config.is_output_colorized);
+        let caret = if self.config.is_match_begin {
+            Component::Caret.to_repr(self.config.is_output_colorized)
+        } else {
+            "".to_string()
+        };
+        let dollar_sign = if self.config.is_match_end {
+            Component::DollarSign.to_repr(self.config.is_output_colorized)
+        } else {
+            "".to_string()
+        };
         let mut regexp = match self.ast {
             Expression::Alternation(_, _) => {
                 format!(

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -35,7 +35,7 @@ mod no_conversion {
             grex.args(&[TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩\\.$\n"));
+                .stdout(predicate::eq("I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩\\.\n"));
         }
 
         #[test]
@@ -44,7 +44,7 @@ mod no_conversion {
             grex.args(&["--ignore-case", "Ä@Ö€Ü", "ä@ö€ü", "Ä@ö€Ü", "ä@Ö€ü"]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("(?i)^ä@ö€ü$\n"));
+                .stdout(predicate::eq("(?i)ä@ö€ü\n"));
         }
 
         #[test]
@@ -53,7 +53,7 @@ mod no_conversion {
             grex.args(&["-a", "b", "c"]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^(?:\\-a|[bc])$\n"));
+                .stdout(predicate::eq("(?:\\-a|[bc])\n"));
         }
 
         #[test]
@@ -61,7 +61,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.$\n",
+                "I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.\n",
             ));
         }
 
@@ -70,7 +70,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n",
+                "I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n",
             ));
         }
 
@@ -81,9 +81,7 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ ♥♥♥\ 36\ and\ ٣\ and\ y̆y̆\ and\ 💩💩\.
-                $
+                I\ \ \ ♥♥♥\ 36\ and\ ٣\ and\ y̆y̆\ and\ 💩💩\.
                 "#,
             )));
         }
@@ -95,9 +93,7 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ \u{2665}\u{2665}\u{2665}\ 36\ and\ \u{663}\ and\ y\u{306}y\u{306}\ and\ \u{1f4a9}\u{1f4a9}\.
-                $
+                I\ \ \ \u{2665}\u{2665}\u{2665}\ 36\ and\ \u{663}\ and\ y\u{306}y\u{306}\ and\ \u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -109,9 +105,7 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ \u{2665}\u{2665}\u{2665}\ 36\ and\ \u{663}\ and\ y\u{306}y\u{306}\ and\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                I\ \ \ \u{2665}\u{2665}\u{2665}\ 36\ and\ \u{663}\ and\ y\u{306}y\u{306}\ and\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -125,7 +119,7 @@ mod no_conversion {
             grex.args(&["-f", file.path().to_str().unwrap()]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^(?:b\\\\n|äöü|[ac♥])$\n"));
+                .stdout(predicate::eq("(?:b\\\\n|äöü|[ac♥])\n"));
         }
 
         #[test]
@@ -184,7 +178,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}♥{3} 36 and ٣ and (?:y̆){2} and 💩{2}\\.$\n",
+                "I {3}♥{3} 36 and ٣ and (?:y̆){2} and 💩{2}\\.\n",
             ));
         }
 
@@ -194,7 +188,7 @@ mod no_conversion {
             grex.args(&["--repetitions", "--ignore-case", "ÄÖÜäöü@Ö€", "äöüÄöÜ@ö€"]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("(?i)^(?:äöü){2}@ö€$\n"));
+                .stdout(predicate::eq("(?i)(?:äöü){2}@ö€\n"));
         }
 
         #[test]
@@ -202,7 +196,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and \\u{1f4a9}{2}\\.$\n",
+                "I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and \\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -211,7 +205,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -222,13 +216,11 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}♥{3}\ 36\ and\ ٣\ and\ 
-                  (?:
-                    y̆
-                  ){2}
-                  \ and\ 💩{2}\.
-                $
+                I\ {3}♥{3}\ 36\ and\ ٣\ and\ 
+                (?:
+                  y̆
+                ){2}
+                \ and\ 💩{2}\.
                 "#
             )));
         }
@@ -240,13 +232,11 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}\u{2665}{3}\ 36\ and\ \u{663}\ and\ 
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \ and\ \u{1f4a9}{2}\.
-                $
+                I\ {3}\u{2665}{3}\ 36\ and\ \u{663}\ and\ 
+                (?:
+                  y\u{306}
+                ){2}
+                \ and\ \u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -264,17 +254,15 @@ mod no_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}\u{2665}{3}\ 36\ and\ \u{663}\ and\ 
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \ and\ 
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                I\ {3}\u{2665}{3}\ 36\ and\ \u{663}\ and\ 
+                (?:
+                  y\u{306}
+                ){2}
+                \ and\ 
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -285,7 +273,7 @@ mod no_conversion {
             grex.args(&["--repetitions", "--min-repetitions", "2", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^I {3}♥{3} 36 and ٣ and y̆y̆ and 💩💩\\.$\n"));
+                .stdout(predicate::eq("I {3}♥{3} 36 and ٣ and y̆y̆ and 💩💩\\.\n"));
         }
 
         #[test]
@@ -293,7 +281,7 @@ mod no_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--min-substring-length", "2", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   ♥♥♥ 36 and ٣ and (?:y̆){2} and 💩💩\\.$\n",
+                "I   ♥♥♥ 36 and ٣ and (?:y̆){2} and 💩💩\\.\n",
             ));
         }
 
@@ -309,7 +297,7 @@ mod no_conversion {
         #[test]
         fn fails_with_minimum_repetitions_equal_to_invalid_value() {
             let mut grex = init_command();
-            grex.args(&["--min-repetitions", "§!$", TEST_CASE]);
+            grex.args(&["--min-repetitions", "§!", TEST_CASE]);
             grex.assert().failure().stderr(predicate::str::contains(
                 "Value is not a valid unsigned integer",
             ));
@@ -327,7 +315,7 @@ mod no_conversion {
         #[test]
         fn fails_with_minimum_substring_length_equal_to_invalid_value() {
             let mut grex = init_command();
-            grex.args(&["--min-substring-length", "§!$", TEST_CASE]);
+            grex.args(&["--min-substring-length", "§!", TEST_CASE]);
             grex.assert().failure().stderr(predicate::str::contains(
                 "Value is not a valid unsigned integer",
             ));
@@ -346,7 +334,7 @@ mod digit_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   ♥♥♥ \\d\\d and \\d and y̆y̆ and 💩💩\\.$\n",
+                "I   ♥♥♥ \\d\\d and \\d and y̆y̆ and 💩💩\\.\n",
             ));
         }
 
@@ -355,7 +343,7 @@ mod digit_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.$\n",
+                "I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.\n",
             ));
         }
 
@@ -364,7 +352,7 @@ mod digit_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -375,9 +363,7 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ ♥♥♥\ \d\d\ and\ \d\ and\ y̆y̆\ and\ 💩💩\.
-                $
+                I\ \ \ ♥♥♥\ \d\d\ and\ \d\ and\ y̆y̆\ and\ 💩💩\.
                 "#
             )));
         }
@@ -389,9 +375,7 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ and\ \d\ and\ y\u{306}y\u{306}\ and\ \u{1f4a9}\u{1f4a9}\.
-                $
+                I\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ and\ \d\ and\ y\u{306}y\u{306}\ and\ \u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -409,9 +393,7 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ and\ \d\ and\ y\u{306}y\u{306}\ and\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                I\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ and\ \d\ and\ y\u{306}y\u{306}\ and\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -422,7 +404,7 @@ mod digit_conversion {
             grex.args(&["--capture-groups", "abc", "def"]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^(abc|def)$\n"));
+                .stdout(predicate::eq("(abc|def)\n"));
         }
     }
 
@@ -434,7 +416,7 @@ mod digit_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--digits", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}♥{3} \\d(?:\\d and ){2}(?:y̆){2} and 💩{2}\\.$\n",
+                "I {3}♥{3} \\d(?:\\d and ){2}(?:y̆){2} and 💩{2}\\.\n",
             ));
         }
 
@@ -443,7 +425,7 @@ mod digit_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--digits", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and \\u{1f4a9}{2}\\.$\n",
+                "I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and \\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -458,7 +440,7 @@ mod digit_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -469,16 +451,14 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}♥{3}\ \d
-                  (?:
-                    \d\ and\ 
-                  ){2}
-                  (?:
-                    y̆
-                  ){2}
-                  \ and\ 💩{2}\.
-                $
+                I\ {3}♥{3}\ \d
+                (?:
+                  \d\ and\ 
+                ){2}
+                (?:
+                  y̆
+                ){2}
+                \ and\ 💩{2}\.
                 "#
             )));
         }
@@ -496,16 +476,14 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}\u{2665}{3}\ \d
-                  (?:
-                    \d\ and\ 
-                  ){2}
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \ and\ \u{1f4a9}{2}\.
-                $
+                I\ {3}\u{2665}{3}\ \d
+                (?:
+                  \d\ and\ 
+                ){2}
+                (?:
+                  y\u{306}
+                ){2}
+                \ and\ \u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -524,20 +502,18 @@ mod digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\ {3}\u{2665}{3}\ \d
-                  (?:
-                    \d\ and\ 
-                  ){2}
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \ and\ 
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                I\ {3}\u{2665}{3}\ \d
+                (?:
+                  \d\ and\ 
+                ){2}
+                (?:
+                  y\u{306}
+                ){2}
+                \ and\ 
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -553,7 +529,7 @@ mod digit_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I {3}♥{3} \\d\\d and \\d and y̆y̆ and 💩💩\\.$\n",
+                "I {3}♥{3} \\d\\d and \\d and y̆y̆ and 💩💩\\.\n",
             ));
         }
 
@@ -568,7 +544,7 @@ mod digit_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I   ♥♥♥ \\d(?:\\d and ){2}(?:y̆){2} and 💩💩\\.$\n",
+                "I   ♥♥♥ \\d(?:\\d and ){2}(?:y̆){2} and 💩💩\\.\n",
             ));
         }
     }
@@ -585,7 +561,7 @@ mod space_conversion {
             let mut grex = init_command();
             grex.args(&["--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s♥♥♥\\s36\\sand\\s٣\\sand\\sy̆y̆\\sand\\s💩💩\\.$\n",
+                "I\\s\\s\\s♥♥♥\\s36\\sand\\s٣\\sand\\sy̆y̆\\sand\\s💩💩\\.\n",
             ));
         }
 
@@ -594,7 +570,7 @@ mod space_conversion {
             let mut grex = init_command();
             grex.args(&["--spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -603,7 +579,7 @@ mod space_conversion {
             let mut grex = init_command();
             grex.args(&["--spaces", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -614,9 +590,7 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s♥♥♥\s36\sand\s٣\sand\sy̆y̆\sand\s💩💩\.
-                $
+                I\s\s\s♥♥♥\s36\sand\s٣\sand\sy̆y̆\sand\s💩💩\.
                 "#
             )));
         }
@@ -628,9 +602,7 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s\u{2665}\u{2665}\u{2665}\s36\sand\s\u{663}\sand\sy\u{306}y\u{306}\sand\s\u{1f4a9}\u{1f4a9}\.
-                $
+                I\s\s\s\u{2665}\u{2665}\u{2665}\s36\sand\s\u{663}\sand\sy\u{306}y\u{306}\sand\s\u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -648,9 +620,7 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s\u{2665}\u{2665}\u{2665}\s36\sand\s\u{663}\sand\sy\u{306}y\u{306}\sand\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                I\s\s\s\u{2665}\u{2665}\u{2665}\s36\sand\s\u{663}\sand\sy\u{306}y\u{306}\sand\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -664,7 +634,7 @@ mod space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\s(?:y̆){2}\\sand\\s💩{2}\\.$\n",
+                "I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\s(?:y̆){2}\\sand\\s💩{2}\\.\n",
             ));
         }
 
@@ -673,7 +643,7 @@ mod space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.$\n",
+                "I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -688,7 +658,7 @@ mod space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -699,13 +669,11 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}♥{3}\s36\sand\s٣\sand\s
-                  (?:
-                    y̆
-                  ){2}
-                  \sand\s💩{2}\.
-                $
+                I\s{3}♥{3}\s36\sand\s٣\sand\s
+                (?:
+                  y̆
+                ){2}
+                \sand\s💩{2}\.
                 "#
             )));
         }
@@ -723,13 +691,11 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}\u{2665}{3}\s36\sand\s\u{663}\sand\s
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \sand\s\u{1f4a9}{2}\.
-                $
+                I\s{3}\u{2665}{3}\s36\sand\s\u{663}\sand\s
+                (?:
+                  y\u{306}
+                ){2}
+                \sand\s\u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -748,17 +714,15 @@ mod space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}\u{2665}{3}\s36\sand\s\u{663}\sand\s
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \sand\s
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                I\s{3}\u{2665}{3}\s36\sand\s\u{663}\sand\s
+                (?:
+                  y\u{306}
+                ){2}
+                \sand\s
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -776,7 +740,7 @@ mod word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   ♥♥♥ \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.$\n",
+                "\\w   ♥♥♥ \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.\n",
             ));
         }
 
@@ -785,7 +749,7 @@ mod word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -794,7 +758,7 @@ mod word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -805,9 +769,7 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ ♥♥♥\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ 💩💩\.
-                $
+                \w\ \ \ ♥♥♥\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ 💩💩\.
                 "#
             )));
         }
@@ -819,9 +781,7 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ \u{2665}\u{2665}\u{2665}\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{1f4a9}\u{1f4a9}\.
-                $
+                \w\ \ \ \u{2665}\u{2665}\u{2665}\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -839,9 +799,7 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ \u{2665}\u{2665}\u{2665}\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                \w\ \ \ \u{2665}\u{2665}\u{2665}\ \w\w\ \w\w\w\ \w\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -855,7 +813,7 @@ mod word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}♥{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩{2}\\.$\n",
+                "\\w {3}♥{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩{2}\\.\n",
             ));
         }
 
@@ -864,7 +822,7 @@ mod word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} \\u{1f4a9}{2}\\.$\n",
+                "\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} \\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -879,7 +837,7 @@ mod word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -890,9 +848,7 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}♥{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ 💩{2}\.
-                $
+                \w\ {3}♥{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ 💩{2}\.
                 "#
             )));
         }
@@ -910,9 +866,7 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}\u{2665}{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ \u{1f4a9}{2}\.
-                $
+                \w\ {3}\u{2665}{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ \u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -931,13 +885,11 @@ mod word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}\u{2665}{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ 
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                \w\ {3}\u{2665}{3}\ \w{2}\ \w{3}\ \w\ \w{3}\ \w{4}\ \w{3}\ 
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -955,7 +907,7 @@ mod digit_space_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s♥♥♥\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\.$\n",
+                "I\\s\\s\\s♥♥♥\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\.\n",
             ));
         }
 
@@ -964,7 +916,7 @@ mod digit_space_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -979,7 +931,7 @@ mod digit_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -990,9 +942,7 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s♥♥♥\s\d\d\sand\s\d\sand\sy̆y̆\sand\s💩💩\.
-                $
+                I\s\s\s♥♥♥\s\d\d\sand\s\d\sand\sy̆y̆\sand\s💩💩\.
                 "#
             )));
         }
@@ -1004,9 +954,7 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\sand\s\d\sand\sy\u{306}y\u{306}\sand\s\u{1f4a9}\u{1f4a9}\.
-                $
+                I\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\sand\s\d\sand\sy\u{306}y\u{306}\sand\s\u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -1025,9 +973,7 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\sand\s\d\sand\sy\u{306}y\u{306}\sand\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                I\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\sand\s\d\sand\sy\u{306}y\u{306}\sand\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -1041,7 +987,7 @@ mod digit_space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--digits", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}♥{3}\\s\\d(?:\\d\\sand\\s){2}(?:y̆){2}\\sand\\s💩{2}\\.$\n",
+                "I\\s{3}♥{3}\\s\\d(?:\\d\\sand\\s){2}(?:y̆){2}\\sand\\s💩{2}\\.\n",
             ));
         }
 
@@ -1056,7 +1002,7 @@ mod digit_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.$\n",
+                "I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -1072,7 +1018,7 @@ mod digit_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -1089,16 +1035,14 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}♥{3}\s\d
-                  (?:
-                    \d\sand\s
-                  ){2}
-                  (?:
-                    y̆
-                  ){2}
-                  \sand\s💩{2}\.
-                $
+                I\s{3}♥{3}\s\d
+                (?:
+                  \d\sand\s
+                ){2}
+                (?:
+                  y̆
+                ){2}
+                \sand\s💩{2}\.
                 "#
             )));
         }
@@ -1117,16 +1061,14 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}\u{2665}{3}\s\d
-                  (?:
-                    \d\sand\s
-                  ){2}
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \sand\s\u{1f4a9}{2}\.
-                $
+                I\s{3}\u{2665}{3}\s\d
+                (?:
+                  \d\sand\s
+                ){2}
+                (?:
+                  y\u{306}
+                ){2}
+                \sand\s\u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -1146,20 +1088,18 @@ mod digit_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\s{3}\u{2665}{3}\s\d
-                  (?:
-                    \d\sand\s
-                  ){2}
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \sand\s
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                I\s{3}\u{2665}{3}\s\d
+                (?:
+                  \d\sand\s
+                ){2}
+                (?:
+                  y\u{306}
+                ){2}
+                \sand\s
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -1177,7 +1117,7 @@ mod digit_word_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   ♥♥♥ \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.$\n",
+                "\\w   ♥♥♥ \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.\n",
             ));
         }
 
@@ -1186,7 +1126,7 @@ mod digit_word_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -1201,7 +1141,7 @@ mod digit_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -1212,9 +1152,7 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ ♥♥♥\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ 💩💩\.
-                $
+                \w\ \ \ ♥♥♥\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ 💩💩\.
                 "#
             )));
         }
@@ -1226,9 +1164,7 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{1f4a9}\u{1f4a9}\.
-                $
+                \w\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -1247,9 +1183,7 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                \w\ \ \ \u{2665}\u{2665}\u{2665}\ \d\d\ \w\w\w\ \d\ \w\w\w\ \w\w\w\w\ \w\w\w\ \u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -1263,7 +1197,7 @@ mod digit_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--digits", "--words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}♥{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} 💩{2}\\.$\n",
+                "\\w {3}♥{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} 💩{2}\\.\n",
             ));
         }
 
@@ -1278,7 +1212,7 @@ mod digit_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} \\u{1f4a9}{2}\\.$\n",
+                "\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} \\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -1294,7 +1228,7 @@ mod digit_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -1311,13 +1245,11 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}♥{3}\ \d
-                  (?:
-                    \d\ \w{3}\ 
-                  ){2}
-                  \w{4}\ \w{3}\ 💩{2}\.
-                $
+                \w\ {3}♥{3}\ \d
+                (?:
+                  \d\ \w{3}\ 
+                ){2}
+                \w{4}\ \w{3}\ 💩{2}\.
                 "#
             )));
         }
@@ -1336,13 +1268,11 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}\u{2665}{3}\ \d
-                  (?:
-                    \d\ \w{3}\ 
-                  ){2}
-                  \w{4}\ \w{3}\ \u{1f4a9}{2}\.
-                $
+                \w\ {3}\u{2665}{3}\ \d
+                (?:
+                  \d\ \w{3}\ 
+                ){2}
+                \w{4}\ \w{3}\ \u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -1362,17 +1292,15 @@ mod digit_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\ {3}\u{2665}{3}\ \d
-                  (?:
-                    \d\ \w{3}\ 
-                  ){2}
-                  \w{4}\ \w{3}\ 
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                \w\ {3}\u{2665}{3}\ \d
+                (?:
+                  \d\ \w{3}\ 
+                ){2}
+                \w{4}\ \w{3}\ 
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -1390,7 +1318,7 @@ mod space_word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s♥♥♥\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.$\n",
+                "\\w\\s\\s\\s♥♥♥\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.\n",
             ));
         }
 
@@ -1399,7 +1327,7 @@ mod space_word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -1414,7 +1342,7 @@ mod space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -1425,9 +1353,7 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s♥♥♥\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s💩💩\.
-                $
+                \w\s\s\s♥♥♥\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s💩💩\.
                 "#
             )));
         }
@@ -1439,9 +1365,7 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s\u{2665}\u{2665}\u{2665}\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{1f4a9}\u{1f4a9}\.
-                $
+                \w\s\s\s\u{2665}\u{2665}\u{2665}\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -1460,9 +1384,7 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s\u{2665}\u{2665}\u{2665}\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                \w\s\s\s\u{2665}\u{2665}\u{2665}\s\w\w\s\w\w\w\s\w\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -1476,7 +1398,7 @@ mod space_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--words", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}♥{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s💩{2}\\.$\n",
+                "\\w\\s{3}♥{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s💩{2}\\.\n",
             ));
         }
 
@@ -1491,7 +1413,7 @@ mod space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.$\n",
+                "\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -1507,7 +1429,7 @@ mod space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -1524,9 +1446,7 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}♥{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s💩{2}\.
-                $
+                \w\s{3}♥{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s💩{2}\.
                 "#
             )));
         }
@@ -1545,9 +1465,7 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}\u{2665}{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s\u{1f4a9}{2}\.
-                $
+                \w\s{3}\u{2665}{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s\u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -1567,13 +1485,11 @@ mod space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}\u{2665}{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                \w\s{3}\u{2665}{3}\s\w{2}\s\w{3}\s\w\s\w{3}\s\w{4}\s\w{3}\s
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -1591,7 +1507,7 @@ mod digit_space_word_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--words", "--spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s♥♥♥\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.$\n",
+                "\\w\\s\\s\\s♥♥♥\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.\n",
             ));
         }
 
@@ -1600,7 +1516,7 @@ mod digit_space_word_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--words", "--spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.$\n"
+                "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.\n"
             ));
         }
 
@@ -1616,7 +1532,7 @@ mod digit_space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$\n"
+                "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.\n"
             ));
         }
 
@@ -1627,9 +1543,7 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s♥♥♥\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s💩💩\.
-                $
+                \w\s\s\s♥♥♥\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s💩💩\.
                 "#
             )));
         }
@@ -1648,9 +1562,7 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{1f4a9}\u{1f4a9}\.
-                $
+                \w\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{1f4a9}\u{1f4a9}\.
                 "#
             )));
         }
@@ -1670,9 +1582,7 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
-                $
+                \w\s\s\s\u{2665}\u{2665}\u{2665}\s\d\d\s\w\w\w\s\d\s\w\w\w\s\w\w\w\w\s\w\w\w\s\u{d83d}\u{dca9}\u{d83d}\u{dca9}\.
                 "#
             )));
         }
@@ -1692,7 +1602,7 @@ mod digit_space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}♥{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s💩{2}\\.$\n",
+                "\\w\\s{3}♥{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s💩{2}\\.\n",
             ));
         }
 
@@ -1708,7 +1618,7 @@ mod digit_space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.$\n",
+                "\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.\n",
             ));
         }
 
@@ -1725,7 +1635,7 @@ mod digit_space_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.$\n",
+                "\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.\n",
             ));
         }
 
@@ -1743,13 +1653,11 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}♥{3}\s\d
-                  (?:
-                    \d\s\w{3}\s
-                  ){2}
-                  \w{4}\s\w{3}\s💩{2}\.
-                $
+                \w\s{3}♥{3}\s\d
+                (?:
+                  \d\s\w{3}\s
+                ){2}
+                \w{4}\s\w{3}\s💩{2}\.
                 "#
             )));
         }
@@ -1769,13 +1677,11 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}\u{2665}{3}\s\d
-                  (?:
-                    \d\s\w{3}\s
-                  ){2}
-                  \w{4}\s\w{3}\s\u{1f4a9}{2}\.
-                $
+                \w\s{3}\u{2665}{3}\s\d
+                (?:
+                  \d\s\w{3}\s
+                ){2}
+                \w{4}\s\w{3}\s\u{1f4a9}{2}\.
                 "#
             )));
         }
@@ -1796,17 +1702,15 @@ mod digit_space_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\s{3}\u{2665}{3}\s\d
-                  (?:
-                    \d\s\w{3}\s
-                  ){2}
-                  \w{4}\s\w{3}\s
-                  (?:
-                    \u{d83d}\u{dca9}
-                  ){2}
-                  \.
-                $
+                \w\s{3}\u{2665}{3}\s\d
+                (?:
+                  \d\s\w{3}\s
+                ){2}
+                \w{4}\s\w{3}\s
+                (?:
+                  \u{d83d}\u{dca9}
+                ){2}
+                \.
                 "#
             )));
         }
@@ -1824,7 +1728,7 @@ mod non_digit_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -1833,7 +1737,7 @@ mod non_digit_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -1842,7 +1746,7 @@ mod non_digit_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -1853,9 +1757,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D٣\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D٣\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -1867,9 +1769,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -1887,9 +1787,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -1904,7 +1802,7 @@ mod non_digit_conversion {
             grex.args(&["--repetitions", "--non-digits", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}٣\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}٣\\D{17}\n"));
         }
 
         #[test]
@@ -1913,7 +1811,7 @@ mod non_digit_conversion {
             grex.args(&["--repetitions", "--non-digits", "--escape", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}\\u{663}\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}\\u{663}\\D{17}\n"));
         }
 
         #[test]
@@ -1928,7 +1826,7 @@ mod non_digit_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}\\u{663}\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}\\u{663}\\D{17}\n"));
         }
 
         #[test]
@@ -1938,9 +1836,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}٣\D{17}
-                $
+                \D{8}36\D{5}٣\D{17}
                 "#
             )));
         }
@@ -1958,9 +1854,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}\u{663}\D{17}
-                $
+                \D{8}36\D{5}\u{663}\D{17}
                 "#
             )));
         }
@@ -1979,9 +1873,7 @@ mod non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}\u{663}\D{17}
-                $
+                \D{8}36\D{5}\u{663}\D{17}
                 "#
             )));
         }
@@ -1999,7 +1891,7 @@ mod non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--non-spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S$\n",
+                "\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S\n",
             ));
         }
 
@@ -2008,7 +1900,7 @@ mod non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--non-spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S$\n",
+                "\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S\n",
             ));
         }
 
@@ -2017,7 +1909,7 @@ mod non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--non-spaces", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S$\n",
+                "\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S\n",
             ));
         }
 
@@ -2028,9 +1920,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
-                $
+                \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
                 "#
             )));
         }
@@ -2042,9 +1932,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
-                $
+                \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
                 "#
             )));
         }
@@ -2062,9 +1950,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
-                $
+                \S\ \ \ \S\S\S\ \S\S\ \S\S\S\ \S\ \S\S\S\ \S\S\S\S\ \S\S\S\ \S\S\S
                 "#
             )));
         }
@@ -2078,7 +1964,7 @@ mod non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--non-spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}$\n",
+                "\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}\n",
             ));
         }
 
@@ -2087,7 +1973,7 @@ mod non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--non-spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}$\n",
+                "\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}\n",
             ));
         }
 
@@ -2102,7 +1988,7 @@ mod non_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}$\n",
+                "\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}\n",
             ));
         }
 
@@ -2113,9 +1999,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
-                $
+                \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
                 "#
             )));
         }
@@ -2133,9 +2017,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
-                $
+                \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
                 "#
             )));
         }
@@ -2154,9 +2036,7 @@ mod non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
-                $
+                \S\ {3}\S{3}\ \S{2}\ \S{3}\ \S\ \S{3}\ \S{4}\ \S{3}\ \S{3}
                 "#
             )));
         }
@@ -2174,7 +2054,7 @@ mod non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W٣\\Wand\\Wy̆y̆\\Wand\\W\\W\\W\\W$\n",
+                "I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W٣\\Wand\\Wy̆y̆\\Wand\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2183,7 +2063,7 @@ mod non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W$\n",
+                "I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2192,7 +2072,7 @@ mod non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-words", "--escape", "--with-surrogates", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W$\n",
+                "I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2203,9 +2083,7 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W\W\W\W\W\W\W36\Wand\W٣\Wand\Wy̆y̆\Wand\W\W\W\W
-                $
+                I\W\W\W\W\W\W\W36\Wand\W٣\Wand\Wy̆y̆\Wand\W\W\W\W
                 "#
             )));
         }
@@ -2217,9 +2095,7 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W\W\W\W\W\W\W36\Wand\W\u{663}\Wand\Wy\u{306}y\u{306}\Wand\W\W\W\W
-                $
+                I\W\W\W\W\W\W\W36\Wand\W\u{663}\Wand\Wy\u{306}y\u{306}\Wand\W\W\W\W
                 "#
             )));
         }
@@ -2237,9 +2113,7 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W\W\W\W\W\W\W36\Wand\W\u{663}\Wand\Wy\u{306}y\u{306}\Wand\W\W\W\W
-                $
+                I\W\W\W\W\W\W\W36\Wand\W\u{663}\Wand\Wy\u{306}y\u{306}\Wand\W\W\W\W
                 "#
             )));
         }
@@ -2253,7 +2127,7 @@ mod non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W{7}36\\Wand\\W٣\\Wand\\W(?:y̆){2}\\Wand\\W{4}$\n",
+                "I\\W{7}36\\Wand\\W٣\\Wand\\W(?:y̆){2}\\Wand\\W{4}\n",
             ));
         }
 
@@ -2262,7 +2136,7 @@ mod non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--non-words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}$\n",
+                "I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}\n",
             ));
         }
 
@@ -2277,7 +2151,7 @@ mod non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}$\n",
+                "I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}\n",
             ));
         }
 
@@ -2288,13 +2162,11 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W{7}36\Wand\W٣\Wand\W
-                  (?:
-                    y̆
-                  ){2}
-                  \Wand\W{4}
-                $
+                I\W{7}36\Wand\W٣\Wand\W
+                (?:
+                  y̆
+                ){2}
+                \Wand\W{4}
                 "#
             )));
         }
@@ -2312,13 +2184,11 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W{7}36\Wand\W\u{663}\Wand\W
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \Wand\W{4}
-                $
+                I\W{7}36\Wand\W\u{663}\Wand\W
+                (?:
+                  y\u{306}
+                ){2}
+                \Wand\W{4}
                 "#
             )));
         }
@@ -2337,13 +2207,11 @@ mod non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  I\W{7}36\Wand\W\u{663}\Wand\W
-                  (?:
-                    y\u{306}
-                  ){2}
-                  \Wand\W{4}
-                $
+                I\W{7}36\Wand\W\u{663}\Wand\W
+                (?:
+                  y\u{306}
+                ){2}
+                \Wand\W{4}
                 "#
             )));
         }
@@ -2361,7 +2229,7 @@ mod non_digit_non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--non-spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2370,7 +2238,7 @@ mod non_digit_non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--non-spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2385,7 +2253,7 @@ mod non_digit_non_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2396,9 +2264,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2416,9 +2282,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2437,9 +2301,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2454,7 +2316,7 @@ mod non_digit_non_space_conversion {
             grex.args(&["--repetitions", "--non-digits", "--non-spaces", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -2469,7 +2331,7 @@ mod non_digit_non_space_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -2485,7 +2347,7 @@ mod non_digit_non_space_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -2501,9 +2363,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -2522,9 +2382,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -2544,9 +2402,7 @@ mod non_digit_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -2564,7 +2420,7 @@ mod non_digit_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2573,7 +2429,7 @@ mod non_digit_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--non-words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2588,7 +2444,7 @@ mod non_digit_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2599,9 +2455,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D٣\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D٣\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2619,9 +2473,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2640,9 +2492,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D36\D\D\D\D\D\u{663}\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -2657,7 +2507,7 @@ mod non_digit_non_word_conversion {
             grex.args(&["--repetitions", "--non-digits", "--non-words", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}٣\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}٣\\D{17}\n"));
         }
 
         #[test]
@@ -2672,7 +2522,7 @@ mod non_digit_non_word_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}\\u{663}\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}\\u{663}\\D{17}\n"));
         }
 
         #[test]
@@ -2688,7 +2538,7 @@ mod non_digit_non_word_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}36\\D{5}\\u{663}\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}36\\D{5}\\u{663}\\D{17}\n"));
         }
 
         #[test]
@@ -2704,9 +2554,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}٣\D{17}
-                $
+                \D{8}36\D{5}٣\D{17}
                 "#
             )));
         }
@@ -2725,9 +2573,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}\u{663}\D{17}
-                $
+                \D{8}36\D{5}\u{663}\D{17}
                 "#
             )));
         }
@@ -2747,9 +2593,7 @@ mod non_digit_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}36\D{5}\u{663}\D{17}
-                $
+                \D{8}36\D{5}\u{663}\D{17}
                 "#
             )));
         }
@@ -2767,7 +2611,7 @@ mod non_space_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-spaces", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W$\n",
+                "\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2776,7 +2620,7 @@ mod non_space_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-spaces", "--non-words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W$\n",
+                "\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2791,7 +2635,7 @@ mod non_space_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W$\n",
+                "\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W\n",
             ));
         }
 
@@ -2802,9 +2646,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
-                $
+                \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
                 "#
             )));
         }
@@ -2822,9 +2664,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
-                $
+                \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
                 "#
             )));
         }
@@ -2843,9 +2683,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
-                $
+                \S\W\W\W\W\W\W\W\S\S\W\S\S\S\W\S\W\S\S\S\W\S\S\S\S\W\S\S\S\W\W\W\W
                 "#
             )));
         }
@@ -2859,7 +2697,7 @@ mod non_space_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--non-spaces", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}$\n",
+                "\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}\n",
             ));
         }
 
@@ -2874,7 +2712,7 @@ mod non_space_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}$\n",
+                "\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}\n",
             ));
         }
 
@@ -2890,7 +2728,7 @@ mod non_space_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}$\n",
+                "\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}\n",
             ));
         }
 
@@ -2907,9 +2745,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
-                $
+                \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
                 "#
             )));
         }
@@ -2928,9 +2764,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
-                $
+                \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
                 "#
             )));
         }
@@ -2950,9 +2784,7 @@ mod non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
-                $
+                \S\W{7}\S{2}\W\S{3}\W\S\W\S{3}\W\S{4}\W\S{3}\W{4}
                 "#
             )));
         }
@@ -2970,7 +2802,7 @@ mod non_digit_non_space_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--non-digits", "--non-spaces", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -2985,7 +2817,7 @@ mod non_digit_non_space_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -3001,7 +2833,7 @@ mod non_digit_non_space_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -3018,9 +2850,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3039,9 +2869,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3061,9 +2889,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\S\S\D\D\D\D\D\S\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3084,7 +2910,7 @@ mod non_digit_non_space_non_word_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -3100,7 +2926,7 @@ mod non_digit_non_space_non_word_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -3117,7 +2943,7 @@ mod non_digit_non_space_non_word_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\S{2}\\D{5}\\S\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\S{2}\\D{5}\\S\\D{17}\n"));
         }
 
         #[test]
@@ -3134,9 +2960,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -3156,9 +2980,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -3179,9 +3001,7 @@ mod non_digit_non_space_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\S{2}\D{5}\S\D{17}
-                $
+                \D{8}\S{2}\D{5}\S\D{17}
                 "#
             )));
         }
@@ -3199,7 +3019,7 @@ mod digit_non_digit_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--non-digits", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -3208,7 +3028,7 @@ mod digit_non_digit_conversion {
             let mut grex = init_command();
             grex.args(&["--digits", "--non-digits", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -3223,7 +3043,7 @@ mod digit_non_digit_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$\n",
+                "\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\n",
             ));
         }
 
@@ -3234,9 +3054,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3254,9 +3072,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3275,9 +3091,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
-                $
+                \D\D\D\D\D\D\D\D\d\d\D\D\D\D\D\d\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D\D
                 "#
             )));
         }
@@ -3292,7 +3106,7 @@ mod digit_non_digit_conversion {
             grex.args(&["--repetitions", "--digits", "--non-digits", TEST_CASE]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\d{2}\\D{5}\\d\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\d{2}\\D{5}\\d\\D{17}\n"));
         }
 
         #[test]
@@ -3307,7 +3121,7 @@ mod digit_non_digit_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\d{2}\\D{5}\\d\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\d{2}\\D{5}\\d\\D{17}\n"));
         }
 
         #[test]
@@ -3323,7 +3137,7 @@ mod digit_non_digit_conversion {
             ]);
             grex.assert()
                 .success()
-                .stdout(predicate::eq("^\\D{8}\\d{2}\\D{5}\\d\\D{17}$\n"));
+                .stdout(predicate::eq("\\D{8}\\d{2}\\D{5}\\d\\D{17}\n"));
         }
 
         #[test]
@@ -3339,9 +3153,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\d{2}\D{5}\d\D{17}
-                $
+                \D{8}\d{2}\D{5}\d\D{17}
                 "#
             )));
         }
@@ -3360,9 +3172,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\d{2}\D{5}\d\D{17}
-                $
+                \D{8}\d{2}\D{5}\d\D{17}
                 "#
             )));
         }
@@ -3382,9 +3192,7 @@ mod digit_non_digit_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \D{8}\d{2}\D{5}\d\D{17}
-                $
+                \D{8}\d{2}\D{5}\d\D{17}
                 "#
             )));
         }
@@ -3402,7 +3210,7 @@ mod space_non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--spaces", "--non-spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S$\n",
+                "\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S\n",
             ));
         }
 
@@ -3411,7 +3219,7 @@ mod space_non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--spaces", "--non-spaces", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S$\n",
+                "\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S\n",
             ));
         }
 
@@ -3426,7 +3234,7 @@ mod space_non_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S$\n",
+                "\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S\n",
             ));
         }
 
@@ -3437,9 +3245,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
-                $
+                \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
                 "#
             )));
         }
@@ -3457,9 +3263,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
-                $
+                \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
                 "#
             )));
         }
@@ -3478,9 +3282,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
-                $
+                \S\s\s\s\S\S\S\s\S\S\s\S\S\S\s\S\s\S\S\S\s\S\S\S\S\s\S\S\S\s\S\S\S
                 "#
             )));
         }
@@ -3494,7 +3296,7 @@ mod space_non_space_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--spaces", "--non-spaces", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}$\n",
+                "\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}\n",
             ));
         }
 
@@ -3509,7 +3311,7 @@ mod space_non_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}$\n",
+                "\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}\n",
             ));
         }
 
@@ -3525,7 +3327,7 @@ mod space_non_space_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}$\n",
+                "\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}\n",
             ));
         }
 
@@ -3542,9 +3344,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
-                $
+                \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
                 "#
             )));
         }
@@ -3563,9 +3363,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
-                $
+                \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
                 "#
             )));
         }
@@ -3585,9 +3383,7 @@ mod space_non_space_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
-                $
+                \S\s{3}\S{3}\s\S{2}\s\S{3}\s\S\s\S{3}\s\S{4}\s\S{3}\s\S{3}
                 "#
             )));
         }
@@ -3605,7 +3401,7 @@ mod word_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W$\n",
+                "\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W\n",
             ));
         }
 
@@ -3614,7 +3410,7 @@ mod word_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--words", "--non-words", "--escape", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W$\n",
+                "\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W\n",
             ));
         }
 
@@ -3629,7 +3425,7 @@ mod word_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W$\n",
+                "\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W\n",
             ));
         }
 
@@ -3640,9 +3436,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
-                $
+                \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
                 "#
             )));
         }
@@ -3654,9 +3448,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
-                $
+                \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
                 "#
             )));
         }
@@ -3675,9 +3467,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
-                $
+                \w\W\W\W\W\W\W\W\w\w\W\w\w\w\W\w\W\w\w\w\W\w\w\w\w\W\w\w\w\W\W\W\W
                 "#
             )));
         }
@@ -3691,7 +3481,7 @@ mod word_non_word_conversion {
             let mut grex = init_command();
             grex.args(&["--repetitions", "--words", "--non-words", TEST_CASE]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}$\n",
+                "\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}\n",
             ));
         }
 
@@ -3706,7 +3496,7 @@ mod word_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}$\n",
+                "\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}\n",
             ));
         }
 
@@ -3722,7 +3512,7 @@ mod word_non_word_conversion {
                 TEST_CASE,
             ]);
             grex.assert().success().stdout(predicate::eq(
-                "^\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}$\n",
+                "\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}\n",
             ));
         }
 
@@ -3739,9 +3529,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
-                $
+                \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
                 "#
             )));
         }
@@ -3760,9 +3548,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
-                $
+                \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
                 "#
             )));
         }
@@ -3782,9 +3568,7 @@ mod word_non_word_conversion {
             grex.assert().success().stdout(predicate::eq(indoc!(
                 r#"
                 (?x)
-                ^
-                  \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
-                $
+                \w\W{7}\w{2}\W\w{3}\W\w\W\w{3}\W\w{4}\W\w{3}\W{4}
                 "#
             )));
         }

--- a/tests/lib_integration_tests.rs
+++ b/tests/lib_integration_tests.rs
@@ -28,69 +28,69 @@ mod no_conversion {
         use super::*;
 
         #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec![" "], "^ $"),
-            case(vec!["   "], "^   $"),
-            case(vec!["["], "^\\[$"),
-            case(vec!["a", "("], "^[(a]$"),
-            case(vec!["a", "\n"], "^[\\na]$"),
-            case(vec!["a", "["], "^[\\[a]$"),
-            case(vec!["a", "-", "c", "!"], "^[!\\-ac]$"),
-            case(vec!["a", "b"], "^[ab]$"),
-            case(vec!["a", "b", "c"], "^[a-c]$"),
-            case(vec!["a", "c", "d", "e", "f"], "^[ac-f]$"),
-            case(vec!["a", "b", "x", "d", "e"], "^[abdex]$"),
-            case(vec!["a", "b", "x", "de"], "^(?:de|[abx])$"),
-            case(vec!["a", "b", "c", "x", "d", "e"], "^[a-ex]$"),
-            case(vec!["a", "b", "c", "x", "de"], "^(?:de|[a-cx])$"),
-            case(vec!["a", "b", "c", "d", "e", "f", "o", "x", "y", "z"], "^[a-fox-z]$"),
-            case(vec!["a", "b", "d", "e", "f", "o", "x", "y", "z"], "^[abd-fox-z]$"),
-            case(vec!["1", "2"], "^[12]$"),
-            case(vec!["1", "2", "3"], "^[1-3]$"),
-            case(vec!["1", "3", "4", "5", "6"], "^[13-6]$"),
-            case(vec!["1", "2", "8", "4", "5"], "^[12458]$"),
-            case(vec!["1", "2", "8", "45"], "^(?:45|[128])$"),
-            case(vec!["1", "2", "3", "8", "4", "5"], "^[1-58]$"),
-            case(vec!["1", "2", "3", "8", "45"], "^(?:45|[1-38])$"),
-            case(vec!["1", "2", "3", "5", "7", "8", "9"], "^[1-357-9]$"),
-            case(vec!["a", "b", "bc"], "^(?:bc?|a)$"),
-            case(vec!["a", "b", "bcd"], "^(?:b(?:cd)?|a)$"),
-            case(vec!["a", "ab", "abc"], "^a(?:bc?)?$"),
-            case(vec!["ac", "bc"], "^[ab]c$"),
-            case(vec!["ab", "ac"], "^a[bc]$"),
-            case(vec!["bc", "abc"], "^a?bc$"),
-            case(vec!["ac", "abc"], "^ab?c$"),
-            case(vec!["abc", "abxyc"], "^ab(?:xy)?c$"),
-            case(vec!["ab", "abc"], "^abc?$"),
-            case(vec!["abx", "cdx"], "^(?:ab|cd)x$"),
-            case(vec!["abd", "acd"], "^a[bc]d$"),
-            case(vec!["abc", "abcd"], "^abcd?$"),
-            case(vec!["abc", "abcde"], "^abc(?:de)?$"),
-            case(vec!["ade", "abcde"], "^a(?:bc)?de$"),
-            case(vec!["abcxy", "adexy"], "^a(?:bc|de)xy$"),
-            case(vec!["axy", "abcxy", "adexy"], "^a(?:(?:bc)?|de)xy$"), // goal: "^a(bc|de)?xy$"
-            case(vec!["abcxy", "abcw", "efgh"], "^(?:abc(?:xy|w)|efgh)$"),
-            case(vec!["abcxy", "efgh", "abcw"], "^(?:abc(?:xy|w)|efgh)$"),
-            case(vec!["efgh", "abcxy", "abcw"], "^(?:abc(?:xy|w)|efgh)$"),
-            case(vec!["abxy", "cxy", "efgh"], "^(?:(?:ab|c)xy|efgh)$"),
-            case(vec!["abxy", "efgh", "cxy"], "^(?:(?:ab|c)xy|efgh)$"),
-            case(vec!["efgh", "abxy", "cxy"], "^(?:(?:ab|c)xy|efgh)$"),
-            case(vec!["a", "ä", "o", "ö", "u", "ü"], "^[aouäöü]$"),
-            case(vec!["y̆", "a", "z"], "^(?:y̆|[az])$"), // goal: "^[az]|y\\u{306}$"
-            case(vec!["a", "b\n", "c"], "^(?:b\\n|[ac])$"),
-            case(vec!["a", "b\\n", "c"], "^(?:b\\\\n|[ac])$"),
-            case(vec!["[a-z]", "(d,e,f)"], "^(?:\\(d,e,f\\)|\\[a\\-z\\])$"),
-            case(vec!["3.5", "4.5", "4,5"], "^(?:3\\.5|4[,.]5)$"),
-            case(vec!["\u{b}"], "^\\v$"), // U+000B Line Tabulation
-            case(vec!["\\u{b}"], "^\\\\u\\{b\\}$"),
-            case(vec!["I ♥ cake"], "^I ♥ cake$"),
-            case(vec!["I \u{2665} cake"], "^I ♥ cake$"),
-            case(vec!["I \\u{2665} cake"], "^I \\\\u\\{2665\\} cake$"),
-            case(vec!["I \\u2665 cake"], "^I \\\\u2665 cake$"),
-            case(vec!["My ♥ is yours.", "My 💩 is yours."], "^My [♥💩] is yours\\.$"),
-            case(vec!["[\u{c3e}"], "^\\[\u{c3e}$"),
-            case(vec!["\\\u{10376}"], "^\\\\\u{10376}$"),
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩\\.$")
+            case(vec![""], ""),
+            case(vec![" "], " "),
+            case(vec!["   "], "   "),
+            case(vec!["["], "\\["),
+            case(vec!["a", "("], "[(a]"),
+            case(vec!["a", "\n"], "[\\na]"),
+            case(vec!["a", "["], "[\\[a]"),
+            case(vec!["a", "-", "c", "!"], "[!\\-ac]"),
+            case(vec!["a", "b"], "[ab]"),
+            case(vec!["a", "b", "c"], "[a-c]"),
+            case(vec!["a", "c", "d", "e", "f"], "[ac-f]"),
+            case(vec!["a", "b", "x", "d", "e"], "[abdex]"),
+            case(vec!["a", "b", "x", "de"], "(?:de|[abx])"),
+            case(vec!["a", "b", "c", "x", "d", "e"], "[a-ex]"),
+            case(vec!["a", "b", "c", "x", "de"], "(?:de|[a-cx])"),
+            case(vec!["a", "b", "c", "d", "e", "f", "o", "x", "y", "z"], "[a-fox-z]"),
+            case(vec!["a", "b", "d", "e", "f", "o", "x", "y", "z"], "[abd-fox-z]"),
+            case(vec!["1", "2"], "[12]"),
+            case(vec!["1", "2", "3"], "[1-3]"),
+            case(vec!["1", "3", "4", "5", "6"], "[13-6]"),
+            case(vec!["1", "2", "8", "4", "5"], "[12458]"),
+            case(vec!["1", "2", "8", "45"], "(?:45|[128])"),
+            case(vec!["1", "2", "3", "8", "4", "5"], "[1-58]"),
+            case(vec!["1", "2", "3", "8", "45"], "(?:45|[1-38])"),
+            case(vec!["1", "2", "3", "5", "7", "8", "9"], "[1-357-9]"),
+            case(vec!["a", "b", "bc"], "(?:bc?|a)"),
+            case(vec!["a", "b", "bcd"], "(?:b(?:cd)?|a)"),
+            case(vec!["a", "ab", "abc"], "a(?:bc?)?"),
+            case(vec!["ac", "bc"], "[ab]c"),
+            case(vec!["ab", "ac"], "a[bc]"),
+            case(vec!["bc", "abc"], "a?bc"),
+            case(vec!["ac", "abc"], "ab?c"),
+            case(vec!["abc", "abxyc"], "ab(?:xy)?c"),
+            case(vec!["ab", "abc"], "abc?"),
+            case(vec!["abx", "cdx"], "(?:ab|cd)x"),
+            case(vec!["abd", "acd"], "a[bc]d"),
+            case(vec!["abc", "abcd"], "abcd?"),
+            case(vec!["abc", "abcde"], "abc(?:de)?"),
+            case(vec!["ade", "abcde"], "a(?:bc)?de"),
+            case(vec!["abcxy", "adexy"], "a(?:bc|de)xy"),
+            case(vec!["axy", "abcxy", "adexy"], "a(?:(?:bc)?|de)xy"), // goal: "^a(bc|de)?xy$"
+            case(vec!["abcxy", "abcw", "efgh"], "(?:abc(?:xy|w)|efgh)"),
+            case(vec!["abcxy", "efgh", "abcw"], "(?:abc(?:xy|w)|efgh)"),
+            case(vec!["efgh", "abcxy", "abcw"], "(?:abc(?:xy|w)|efgh)"),
+            case(vec!["abxy", "cxy", "efgh"], "(?:(?:ab|c)xy|efgh)"),
+            case(vec!["abxy", "efgh", "cxy"], "(?:(?:ab|c)xy|efgh)"),
+            case(vec!["efgh", "abxy", "cxy"], "(?:(?:ab|c)xy|efgh)"),
+            case(vec!["a", "ä", "o", "ö", "u", "ü"], "[aouäöü]"),
+            case(vec!["y̆", "a", "z"], "(?:y̆|[az])"), // goal: "^[az]|y\\u{306}$"
+            case(vec!["a", "b\n", "c"], "(?:b\\n|[ac])"),
+            case(vec!["a", "b\\n", "c"], "(?:b\\\\n|[ac])"),
+            case(vec!["[a-z]", "(d,e,f)"], "(?:\\(d,e,f\\)|\\[a\\-z\\])"),
+            case(vec!["3.5", "4.5", "4,5"], "(?:3\\.5|4[,.]5)"),
+            case(vec!["\u{b}"], "\\v"), // U+000B Line Tabulation
+            case(vec!["\\u{b}"], "\\\\u\\{b\\}"),
+            case(vec!["I ♥ cake"], "I ♥ cake"),
+            case(vec!["I \u{2665} cake"], "I ♥ cake"),
+            case(vec!["I \\u{2665} cake"], "I \\\\u\\{2665\\} cake"),
+            case(vec!["I \\u2665 cake"], "I \\\\u2665 cake"),
+            case(vec!["My ♥ is yours.", "My 💩 is yours."], "My [♥💩] is yours\\."),
+            case(vec!["[\u{c3e}"], "\\[\u{c3e}"),
+            case(vec!["\\\u{10376}"], "\\\\\u{10376}"),
+            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩\\.")
         )]
         fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
             let regexp = RegExpBuilder::from(&test_cases).build();
@@ -99,9 +99,9 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["ABC", "abc", "AbC", "aBc"], "(?i)^abc$"),
-            case(vec!["ABC", "zBC", "abc", "AbC", "aBc"], "(?i)^[az]bc$"),
-            case(vec!["Ä@Ö€Ü", "ä@ö€ü", "Ä@ö€Ü", "ä@Ö€ü"], "(?i)^ä@ö€ü$"),
+            case(vec!["ABC", "abc", "AbC", "aBc"], "(?i)abc"),
+            case(vec!["ABC", "zBC", "abc", "AbC", "aBc"], "(?i)[az]bc"),
+            case(vec!["Ä@Ö€Ü", "ä@ö€ü", "Ä@ö€Ü", "ä@Ö€ü"], "(?i)ä@ö€ü"),
         )]
         fn succeeds_with_ignore_case_option(test_cases: Vec<&str>, expected_output: &str) {
             let regexp = RegExpBuilder::from(&test_cases)
@@ -112,11 +112,11 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["My ♥ and 💩 is yours."], "^My \\u{2665} and \\u{1f4a9} is yours\\.$"),
-            case(vec!["My ♥ is yours.", "My 💩 is yours."], "^My (?:\\u{2665}|\\u{1f4a9}) is yours\\.$"),
+            case(vec!["My ♥ and 💩 is yours."], "My \\u{2665} and \\u{1f4a9} is yours\\."),
+            case(vec!["My ♥ is yours.", "My 💩 is yours."], "My (?:\\u{2665}|\\u{1f4a9}) is yours\\."),
             case(
                 vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.$"
+                "I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\."
             )
         )]
         fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
@@ -128,11 +128,11 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["My ♥ and 💩 is yours."], "^My \\u{2665} and \\u{d83d}\\u{dca9} is yours\\.$"),
-            case(vec!["My ♥ is yours.", "My 💩 is yours."], "^My (?:\\u{2665}|\\u{d83d}\\u{dca9}) is yours\\.$"),
+            case(vec!["My ♥ and 💩 is yours."], "My \\u{2665} and \\u{d83d}\\u{dca9} is yours\\."),
+            case(vec!["My ♥ is yours.", "My 💩 is yours."], "My (?:\\u{2665}|\\u{d83d}\\u{dca9}) is yours\\."),
             case(
                 vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
+                "I   \\u{2665}\\u{2665}\\u{2665} 36 and \\u{663} and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
             )
         )]
         fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
@@ -143,10 +143,10 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["a", "b", "bc"], "^(bc?|a)$"),
-            case(vec!["a", "b", "bcd"], "^(b(cd)?|a)$"),
-            case(vec!["a", "ab", "abc"], "^a(bc?)?$"),
-            case(vec!["efgh", "abcxy", "abcw"], "^(abc(xy|w)|efgh)$"),
+            case(vec!["a", "b", "bc"], "(bc?|a)"),
+            case(vec!["a", "b", "bcd"], "(b(cd)?|a)"),
+            case(vec!["a", "ab", "abc"], "a(bc?)?"),
+            case(vec!["efgh", "abcxy", "abcw"], "(abc(xy|w)|efgh)"),
         )]
         fn succeeds_with_capturing_groups_option(test_cases: Vec<&str>, expected_output: &str) {
             let regexp = RegExpBuilder::from(&test_cases)
@@ -159,210 +159,184 @@ mod no_conversion {
         #[rstest(test_cases, expected_output,
             case(vec![""], indoc!(
                 r#"
-                (?x)
-                ^
-                $"#
-            )),
-            case(vec![" "], indoc!(
-                r#"
-                (?x)
-                ^
-                  \ 
-                $"#
-            )),
-            case(vec!["   "], indoc!(
-                r#"
-                (?x)
-                ^
-                  \ \ \ 
-                $"#
-            )),
-            case(vec!["a", "b", "c"], indoc!(
-                r#"
-                (?x)
-                ^
-                  [a-c]
-                $"#
-            )),
-            case(vec!["a", "b", "bc"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    bc?
-                    |
-                    a
-                  )
-                $"#
-            )),
-            case(vec!["a", "ab", "abc"], indoc!(
-                r#"
-                (?x)
-                ^
-                  a
-                  (?:
-                    bc?
-                  )?
-                $"#
-            )),
-            case(vec!["a", "b", "bcd"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    b
-                    (?:
-                      cd
-                    )?
-                    |
-                    a
-                  )
-                $"#
-            )),
-            case(vec!["a", "b", "x", "de"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    de
-                    |
-                    [abx]
-                  )
-                $"#
-            )),
-            case(vec!["[a-z]", "(d,e,f)"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    \(d,e,f\)
-                    |
-                    \[a\-z\]
-                  )
-                $"#
-            )),
-            case(vec!["3.5", "4.5", "4,5"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    3\.5
-                    |
-                    4[,.]5
-                  )
-                $"#
-            ))
-        )]
-        fn succeeds_with_verbose_mode_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases).with_verbose_mode().build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+                (?x)"#
+          )),
+          case(vec![" "], indoc!(
+              r#"
+              (?x)
+              \ "#
+          )),
+          case(vec!["   "], indoc!(
+              r#"
+              (?x)
+              \ \ \ "#
+          )),
+          case(vec!["a", "b", "c"], indoc!(
+              r#"
+              (?x)
+              [a-c]"#
+          )),
+          case(vec!["a", "b", "bc"], indoc!(
+              r#"
+              (?x)
+              (?:
+                bc?
+                |
+                a
+              )"#
+          )),
+          case(vec!["a", "ab", "abc"], indoc!(
+              r#"
+              (?x)
+              a
+              (?:
+                bc?
+              )?"#
+          )),
+          case(vec!["a", "b", "bcd"], indoc!(
+              r#"
+              (?x)
+              (?:
+                b
+                (?:
+                  cd
+                )?
+                |
+                a
+              )"#
+          )),
+          case(vec!["a", "b", "x", "de"], indoc!(
+              r#"
+              (?x)
+              (?:
+                de
+                |
+                [abx]
+              )"#
+          )),
+          case(vec!["[a-z]", "(d,e,f)"], indoc!(
+              r#"
+              (?x)
+              (?:
+                \(d,e,f\)
+                |
+                \[a\-z\]
+              )"#
+          )),
+          case(vec!["3.5", "4.5", "4,5"], indoc!(
+              r#"
+              (?x)
+              (?:
+                3\.5
+                |
+                4[,.]5
+              )"#
+          ))
+      )]
+      fn succeeds_with_verbose_mode_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases).with_verbose_mode().build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["ABC", "abc", "AbC", "aBc"], indoc!(
-                r#"
-                (?ix)
-                ^
-                  abc
-                $"#
-            )),
-            case(vec!["ABC", "zBC", "abc", "AbC", "aBc"], indoc!(
-                r#"
-                (?ix)
-                ^
-                  [az]bc
-                $"#
-            )),
-            case(vec!["Ä@Ö€Ü", "ä@ö€ü", "Ä@ö€Ü", "ä@Ö€ü"], indoc!(
-                r#"
-                (?ix)
-                ^
-                  ä@ö€ü
-                $"#
-            ))
-        )]
-        fn succeeds_with_ignore_case_and_verbose_mode_option(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::CaseInsensitivity])
-                .with_verbose_mode()
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec!["ABC", "abc", "AbC", "aBc"], indoc!(
+              r#"
+              (?ix)
+              abc"#
+          )),
+          case(vec!["ABC", "zBC", "abc", "AbC", "aBc"], indoc!(
+              r#"
+              (?ix)
+              [az]
+              bc"#
+          )),
+          case(vec!["Ä@Ö€Ü", "ä@ö€ü", "Ä@ö€Ü", "ä@Ö€ü"], indoc!(
+              r#"
+              (?ix)
+              ä@ö€ü"#
+          ))
+      )]
+      fn succeeds_with_ignore_case_and_verbose_mode_option(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::CaseInsensitivity])
+              .with_verbose_mode()
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[test]
-        fn succeeds_with_file_input() {
-            let mut file = NamedTempFile::new().unwrap();
-            writeln!(file, "a\nb\nc\r\nxyz").unwrap();
+      #[test]
+      fn succeeds_with_file_input() {
+          let mut file = NamedTempFile::new().unwrap();
+          writeln!(file, "a\nb\nc\r\nxyz").unwrap();
 
-            let expected_output = "^(?:xyz|[a-c])$";
-            let test_cases = vec!["a", "b", "c", "xyz"];
+          let expected_output = "(?:xyz|[a-c])";
+          let test_cases = vec!["a", "b", "c", "xyz"];
 
-            let regexp = RegExpBuilder::from_file(file.path()).build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+          let regexp = RegExpBuilder::from_file(file.path()).build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec![" "], "^ $"),
-            case(vec!["   "], "^ {3}$"),
-            case(vec!["a"], "^a$"),
-            case(vec!["aa"], "^a{2}$"),
-            case(vec!["aaa"], "^a{3}$"),
-            case(vec!["a", "aa"], "^a{1,2}$"),
-            case(vec!["aaa", "a", "aa"], "^a{1,3}$"),
-            case(vec!["aaaa", "a", "aa"], "^(?:a{1,2}|a{4})$"),
-            case(vec!["a", "aa", "aaa", "aaaa", "aaab"], "^(?:a{3}b|a{1,4})$"),
-            case(vec!["baabaaaaaabb"], "^ba{2}ba{6}b{2}$"),
-            case(vec!["aabbaabbaaa"], "^(?:a{2}b{2}){2}a{3}$"),
-            case(vec!["aabbaa"], "^a{2}b{2}a{2}$"),
-            case(vec!["aabbabb"], "^a(?:ab{2}){2}$"),
-            case(vec!["ababab"], "^(?:ab){3}$"),
-            case(vec!["abababa"], "^a(?:ba){3}$"),
-            case(vec!["aababab"], "^a(?:ab){3}$"),
-            case(vec!["abababaa"], "^(?:ab){3}a{2}$"),
-            case(vec!["aaaaaabbbbb"], "^a{6}b{5}$"),
-            case(vec!["aabaababab"], "^(?:a{2}b){2}abab$"), // goal: ^(a{2}b){2}(ab){2}$
-            case(vec!["aaaaaaabbbbbba"], "^a{7}b{6}a$"),
-            case(vec!["abaaaabaaba"], "^abaa(?:a{2}b){2}a$"),
-            case(vec!["bbaababb"], "^b{2}a{2}bab{2}$"),
-            case(vec!["b", "ba"], "^ba?$"),
-            case(vec!["b", "ba", "baa"], "^b(?:a{1,2})?$"),
-            case(vec!["b", "ba", "baaa", "baa"], "^b(?:a{1,3})?$"),
-            case(vec!["b", "ba", "baaaa", "baa"], "^b(?:a{1,2}|a{4})?$"),
-            case(vec!["axy", "abcxyxy", "adexy"], "^a(?:(?:de)?xy|bc(?:xy){2})$"),
-            case(vec!["xy̆y̆y̆y̆z"], "^x(?:y̆){4}z$"),
-            case(vec!["xy̆y̆z", "xy̆y̆y̆z"], "^x(?:y̆){2,3}z$"),
-            case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], "^x(?:(?:y̆){2}|(?:y̆){4})z$"),
-            case(vec!["zyxx", "yxx"], "^z?yx{2}$"),
-            case(vec!["zyxx", "yxx", "yxxx"], "^(?:zyx{2}|yx{2,3})$"),
-            case(vec!["zyxxx", "yxx", "yxxx"], "^(?:zyx{3}|yx{2,3})$"),
-            case(vec!["a", "b\n\n", "c"], "^(?:b\\n{2}|[ac])$"),
-            case(vec!["a", "b\nb\nb", "c"], "^(?:b(?:\\nb){2}|[ac])$"),
-            case(vec!["a", "b\nx\nx", "c"], "^(?:b(?:\\nx){2}|[ac])$"),
-            case(vec!["a", "b\n\t\n\t", "c"], "^(?:b(?:\\n\\t){2}|[ac])$"),
-            case(vec!["a", "b\n", "b\n\n", "b\n\n\n", "c"], "^(?:b\\n{1,3}|[ac])$"),
-            case(vec!["4.5", "3.55"], "^(?:4\\.5|3\\.5{2})$"),
-            case(vec!["4.5", "4.55"], "^4\\.5{1,2}$"),
-            case(vec!["4.5", "4.55", "3.5"], "^(?:3\\.5|4\\.5{1,2})$"),
-            case(vec!["4.5", "44.5", "44.55", "4.55"], "^4{1,2}\\.5{1,2}$"),
-            case(vec!["I ♥♥ cake"], "^I ♥{2} cake$"),
-            case(vec!["I ♥ cake", "I ♥♥ cake"], "^I ♥{1,2} cake$"),
-            case(vec!["I \u{2665}\u{2665} cake"], "^I ♥{2} cake$"),
-            case(vec!["I \\u{2665} cake"], "^I \\\\u\\{26{2}5\\} cake$"),
-            case(vec!["I \\u{2665}\\u{2665} cake"], "^I (?:\\\\u\\{26{2}5\\}){2} cake$"),
-            case(vec!["I \\u2665\\u2665 cake"], "^I (?:\\\\u26{2}5){2} cake$"),
-            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "^My (?:💩{2}|♥{3}) is yours\\.$"),
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^I {3}♥{3} 36 and ٣ and (?:y̆){2} and 💩{2}\\.$")
+      #[rstest(test_cases, expected_output,
+          case(vec![""], ""),
+          case(vec![" "], " "),
+          case(vec!["   "], " {3}"),
+          case(vec!["a"], "a"),
+          case(vec!["aa"], "a{2}"),
+          case(vec!["aaa"], "a{3}"),
+          case(vec!["a", "aa"], "a{1,2}"),
+          case(vec!["aaa", "a", "aa"], "a{1,3}"),
+          case(vec!["aaaa", "a", "aa"], "(?:a{1,2}|a{4})"),
+          case(vec!["a", "aa", "aaa", "aaaa", "aaab"], "(?:a{3}b|a{1,4})"),
+          case(vec!["baabaaaaaabb"], "ba{2}ba{6}b{2}"),
+          case(vec!["aabbaabbaaa"], "(?:a{2}b{2}){2}a{3}"),
+          case(vec!["aabbaa"], "a{2}b{2}a{2}"),
+          case(vec!["aabbabb"], "a(?:ab{2}){2}"),
+          case(vec!["ababab"], "(?:ab){3}"),
+          case(vec!["abababa"], "a(?:ba){3}"),
+          case(vec!["aababab"], "a(?:ab){3}"),
+          case(vec!["abababaa"], "(?:ab){3}a{2}"),
+          case(vec!["aaaaaabbbbb"], "a{6}b{5}"),
+            case(vec!["aaaaaaabbbbbba"], "a{7}b{6}a"),
+            case(vec!["abaaaabaaba"], "abaa(?:a{2}b){2}a"),
+            case(vec!["bbaababb"], "b{2}a{2}bab{2}"),
+            case(vec!["b", "ba"], "ba?"),
+            case(vec!["b", "ba", "baa"], "b(?:a{1,2})?"),
+            case(vec!["b", "ba", "baaa", "baa"], "b(?:a{1,3})?"),
+            case(vec!["b", "ba", "baaaa", "baa"], "b(?:a{1,2}|a{4})?"),
+            case(vec!["axy", "abcxyxy", "adexy"], "a(?:(?:de)?xy|bc(?:xy){2})"),
+            case(vec!["xy̆y̆y̆y̆z"], "x(?:y̆){4}z"),
+            case(vec!["xy̆y̆z", "xy̆y̆y̆z"], "x(?:y̆){2,3}z"),
+            case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], "x(?:(?:y̆){2}|(?:y̆){4})z"),
+            case(vec!["zyxx", "yxx"], "z?yx{2}"),
+            case(vec!["zyxx", "yxx", "yxxx"], "(?:zyx{2}|yx{2,3})"),
+            case(vec!["zyxxx", "yxx", "yxxx"], "(?:zyx{3}|yx{2,3})"),
+            case(vec!["a", "b\n\n", "c"], "(?:b\\n{2}|[ac])"),
+            case(vec!["a", "b\nb\nb", "c"], "(?:b(?:\\nb){2}|[ac])"),
+            case(vec!["a", "b\nx\nx", "c"], "(?:b(?:\\nx){2}|[ac])"),
+            case(vec!["a", "b\n\t\n\t", "c"], "(?:b(?:\\n\\t){2}|[ac])"),
+            case(vec!["a", "b\n", "b\n\n", "b\n\n\n", "c"], "(?:b\\n{1,3}|[ac])"),
+            case(vec!["4.5", "3.55"], "(?:4\\.5|3\\.5{2})"),
+            case(vec!["4.5", "4.55"], "4\\.5{1,2}"),
+            case(vec!["4.5", "4.55", "3.5"], "(?:3\\.5|4\\.5{1,2})"),
+            case(vec!["4.5", "44.5", "44.55", "4.55"], "4{1,2}\\.5{1,2}"),
+            case(vec!["I ♥♥ cake"], "I ♥{2} cake"),
+            case(vec!["I ♥ cake", "I ♥♥ cake"], "I ♥{1,2} cake"),
+            case(vec!["I \u{2665}\u{2665} cake"], "I ♥{2} cake"),
+            case(vec!["I \\u{2665} cake"], "I \\\\u\\{26{2}5\\} cake"),
+            case(vec!["I \\u{2665}\\u{2665} cake"], "I (?:\\\\u\\{26{2}5\\}){2} cake"),
+            case(vec!["I \\u2665\\u2665 cake"], "I (?:\\\\u26{2}5){2} cake"),
+            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "My (?:💩{2}|♥{3}) is yours\\."),
+            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "I {3}♥{3} 36 and ٣ and (?:y̆){2} and 💩{2}\\.")
         )]
         fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
             let regexp = RegExpBuilder::from(&test_cases)
@@ -373,8 +347,8 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["AAAAB", "aaaab", "AaAaB", "aAaAB"], "(?i)^a{4}b$"),
-            case(vec!["ÄÖÜäöü@Ö€", "äöüÄöÜ@ö€"], "(?i)^(?:äöü){2}@ö€$"),
+            case(vec!["AAAAB", "aaaab", "AaAaB", "aAaAB"], "(?i)a{4}b"),
+            case(vec!["ÄÖÜäöü@Ö€", "äöüÄöÜ@ö€"], "(?i)(?:äöü){2}@ö€"),
         )]
         fn succeeds_with_ignore_case_option(test_cases: Vec<&str>, expected_output: &str) {
             let regexp = RegExpBuilder::from(&test_cases)
@@ -385,11 +359,11 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["My ♥♥♥ and 💩💩 is yours."], "^My \\u{2665}{3} and \\u{1f4a9}{2} is yours\\.$"),
-            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "^My (?:\\u{1f4a9}{2}|\\u{2665}{3}) is yours\\.$"),
+            case(vec!["My ♥♥♥ and 💩💩 is yours."], "My \\u{2665}{3} and \\u{1f4a9}{2} is yours\\."),
+            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "My (?:\\u{1f4a9}{2}|\\u{2665}{3}) is yours\\."),
             case(
                 vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and \\u{1f4a9}{2}\\.$"
+                "I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and \\u{1f4a9}{2}\\."
             )
         )]
         fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
@@ -402,11 +376,11 @@ mod no_conversion {
         }
 
         #[rstest(test_cases, expected_output,
-            case(vec!["My ♥♥♥ and 💩💩 is yours."], "^My \\u{2665}{3} and (?:\\u{d83d}\\u{dca9}){2} is yours\\.$"),
-            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "^My (?:(?:\\u{d83d}\\u{dca9}){2}|\\u{2665}{3}) is yours\\.$"),
+            case(vec!["My ♥♥♥ and 💩💩 is yours."], "My \\u{2665}{3} and (?:\\u{d83d}\\u{dca9}){2} is yours\\."),
+            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], "My (?:(?:\\u{d83d}\\u{dca9}){2}|\\u{2665}{3}) is yours\\."),
             case(
                 vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.$"
+                "I {3}\\u{2665}{3} 36 and \\u{663} and (?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\."
             )
         )]
         fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
@@ -421,1542 +395,1518 @@ mod no_conversion {
             case(vec!["   "], indoc!(
                 r#"
                 (?x)
-                ^
-                  \ {3}
-                $"#
-            )),
-            case(vec!["aa"], indoc!(
-                r#"
-                (?x)
-                ^
-                  a{2}
-                $"#
-            )),
-            case(vec!["aaa", "a", "aa"], indoc!(
-                r#"
-                (?x)
-                ^
-                  a{1,3}
-                $"#
-            )),
-            case(vec!["aaaa", "a", "aa"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    a{1,2}
-                    |
-                    a{4}
-                  )
-                $"#
-            )),
-            case(vec!["ababab"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    ab
-                  ){3}
-                $"#
-            )),
-            case(vec!["abababa"], indoc!(
-                r#"
-                (?x)
-                ^
-                  a
-                  (?:
-                    ba
-                  ){3}
-                $"#
-            )),
-            case(vec!["abababaa"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    ab
-                  ){3}
-                  a{2}
-                $"#
-            )),
-            case(vec!["aabaababab"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    a{2}b
-                  ){2}
-                  abab
-                $"#
-            )),
-            case(vec!["abaaaabaaba"], indoc!(
-                r#"
-                (?x)
-                ^
-                  abaa
-                  (?:
-                    a{2}b
-                  ){2}
-                  a
-                $"#
-            )),
-            case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], indoc!(
-                r#"
-                (?x)
-                ^
-                  x
-                  (?:
-                    (?:
-                      y̆
-                    ){2}
-                    |
-                    (?:
-                      y̆
-                    ){4}
-                  )
-                  z
-                $"#
-            )),
-            case(vec!["a", "b\n\t\n\t", "c"], indoc!(
-                r#"
-                (?x)
-                ^
-                  (?:
-                    b
-                    (?:
-                      \n\t
-                    ){2}
-                    |
-                    [ac]
-                  )
-                $"#
-            )),
-            case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], indoc!(
-                r#"
-                (?x)
-                ^
-                  My\ 
-                  (?:
-                    💩{2}
-                    |
-                    ♥{3}
-                  )
-                  \ is\ yours\.
-                $"#
-            ))
-        )]
-        fn succeeds_with_verbose_mode_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_verbose_mode()
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+                \ {3}"#
+          )),
+          case(vec!["aa"], indoc!(
+              r#"
+              (?x)
+              a{2}"#
+          )),
+          case(vec!["aaa", "a", "aa"], indoc!(
+              r#"
+              (?x)
+              a{1,3}"#
+          )),
+          case(vec!["aaaa", "a", "aa"], indoc!(
+              r#"
+              (?x)
+              (?:
+                a{1,2}
+                |
+                a{4}
+              )"#
+          )),
+          case(vec!["ababab"], indoc!(
+              r#"
+              (?x)
+              (?:
+                ab
+              ){3}"#
+          )),
+          case(vec!["abababa"], indoc!(
+              r#"
+              (?x)
+              a
+              (?:
+                ba
+              ){3}"#
+          )),
+          case(vec!["abababaa"], indoc!(
+              r#"
+              (?x)
+              (?:
+                ab
+              ){3}
+              a{2}"#
+          )),
+          case(vec!["aabaababab"], indoc!(
+              r#"
+              (?x)
+              (?:
+                a{2}b
+              ){2}
+              abab"#
+          )),
+          case(vec!["abaaaabaaba"], indoc!(
+              r#"
+              (?x)
+              abaa
+              (?:
+                a{2}b
+              ){2}
+              a"#
+          )),
+          case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], indoc!(
+              r#"
+              (?x)
+              x
+              (?:
+                (?:
+                  y̆
+                ){2}
+                |
+                (?:
+                  y̆
+                ){4}
+              )
+              z"#
+          )),
+          case(vec!["a", "b\n\t\n\t", "c"], indoc!(
+              r#"
+              (?x)
+              (?:
+                b
+                (?:
+                  \n\t
+                ){2}
+                |
+                [ac]
+              )"#
+          )),
+          case(vec!["My ♥♥♥ is yours.", "My 💩💩 is yours."], indoc!(
+              r#"
+              (?x)
+              My\ 
+              (?:
+                💩{2}
+                |
+                ♥{3}
+              )
+              \ is\ yours\."#
+          ))
+      )]
+      fn succeeds_with_verbose_mode_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_verbose_mode()
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec![" "], "^ $"),
-            case(vec!["   "], "^   $"),
-            case(vec!["    "], "^ {4}$"),
-            case(vec!["      "], "^ {6}$"),
-            case(vec!["a"], "^a$"),
-            case(vec!["aa"], "^aa$"),
-            case(vec!["aaa"], "^aaa$"),
-            case(vec!["aaaa"], "^a{4}$"),
-            case(vec!["aaaaa"], "^a{5}$"),
-            case(vec!["aabbaaaabbbabbbbba"], "^aabba{4}bbbab{5}a$"),
-            case(vec!["baabaaaaaabb"], "^baaba{6}bb$"),
-            case(vec!["ababab"], "^ababab$"),
-            case(vec!["abababab"], "^(?:ab){4}$"),
-            case(vec!["abababa"], "^abababa$"),
-            case(vec!["ababababa"], "^a(?:ba){4}$"),
-            case(vec!["aababab"], "^aababab$"),
-            case(vec!["aabababab"], "^a(?:ab){4}$"),
-            case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], "^x(?:y̆y̆|(?:y̆){4})z$"),
-            case(vec!["aaa", "a", "aa"], "^a(?:aa?)?$"),
-            case(vec!["a", "aa", "aaa", "aaaa"], "^(?:aaa|aa?|a{4})$"),
-            case(vec!["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa"], "^(?:aaa|aa?|a{4,6})$")
-        )]
-        fn succeeds_with_increased_minimum_repetitions(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_minimum_repetitions(3)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec![""], ""),
+          case(vec![" "], " "),
+          case(vec!["   "], "   "),
+          case(vec!["    "], " {4}"),
+          case(vec!["      "], " {6}"),
+          case(vec!["a"], "a"),
+          case(vec!["aa"], "aa"),
+          case(vec!["aaa"], "aaa"),
+          case(vec!["aaaa"], "a{4}"),
+          case(vec!["aaaaa"], "a{5}"),
+          case(vec!["aabbaaaabbbabbbbba"], "aabba{4}bbbab{5}a"),
+          case(vec!["baabaaaaaabb"], "baaba{6}bb"),
+          case(vec!["ababab"], "ababab"),
+          case(vec!["abababab"], "(?:ab){4}"),
+          case(vec!["abababa"], "abababa"),
+          case(vec!["ababababa"], "a(?:ba){4}"),
+          case(vec!["aababab"], "aababab"),
+          case(vec!["aabababab"], "a(?:ab){4}"),
+          case(vec!["xy̆y̆z", "xy̆y̆y̆y̆z"], "x(?:y̆y̆|(?:y̆){4})z"),
+          case(vec!["aaa", "a", "aa"], "a(?:aa?)?"),
+          case(vec!["a", "aa", "aaa", "aaaa"], "(?:aaa|aa?|a{4})"),
+          case(vec!["a", "aa", "aaa", "aaaa", "aaaaa", "aaaaaa"], "(?:aaa|aa?|a{4,6})")
+      )]
+      fn succeeds_with_increased_minimum_repetitions(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_minimum_repetitions(3)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["aaa"], "^aaa$"),
-            case(vec!["ababab"], "^ababab$"),
-            case(vec!["abcabcabc"], "^(?:abc){3}$"),
-            case(vec!["abcabcabc", "dede"], "^(?:dede|(?:abc){3})$"),
-            case(vec!["abcabcabc", "defgdefg"], "^(?:(?:defg){2}|(?:abc){3})$")
-        )]
-        fn succeeds_with_increased_minimum_substring_length(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_minimum_substring_length(3)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec!["aaa"], "aaa"),
+          case(vec!["ababab"], "ababab"),
+          case(vec!["abcabcabc"], "(?:abc){3}"),
+          case(vec!["abcabcabc", "dede"], "(?:dede|(?:abc){3})"),
+          case(vec!["abcabcabc", "defgdefg"], "(?:(?:defg){2}|(?:abc){3})")
+      )]
+      fn succeeds_with_increased_minimum_substring_length(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_minimum_substring_length(3)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["abababab"], "^abababab$"),
-            case(vec!["abcabcabc"], "^abcabcabc$"),
-            case(vec!["abcabcabcabc"], "^(?:abc){4}$"),
-            case(vec!["aaaaaaaaaaaa"], "^aaaaaaaaaaaa$"),
-            case(vec!["abababab", "abcabcabcabc"], "^(?:abababab|(?:abc){4})$")
-        )]
-        fn succeeds_with_increased_minimum_repetitions_and_substring_length(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_minimum_repetitions(3)
-                .with_minimum_substring_length(3)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["abababab"], "abababab"),
+          case(vec!["abcabcabc"], "abcabcabc"),
+          case(vec!["abcabcabcabc"], "(?:abc){4}"),
+          case(vec!["aaaaaaaaaaaa"], "aaaaaaaaaaaa"),
+          case(vec!["abababab", "abcabcabcabc"], "(?:abababab|(?:abc){4})")
+      )]
+      fn succeeds_with_increased_minimum_repetitions_and_substring_length(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_minimum_repetitions(3)
+              .with_minimum_substring_length(3)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod digit_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec!["a"], "^a$"),
-            case(vec!["1"], "^\\d$"),
-            case(vec!["-1"], "^\\-\\d$"),
-            case(vec!["12"], "^\\d\\d$"),
-            case(vec!["1", "2"], "^\\d$"),
-            case(vec!["1", "23"], "^\\d(?:\\d)?$"),
-            case(vec!["1", "234"], "^\\d(?:\\d\\d)?$"),
-            case(vec!["8", "234"], "^\\d(?:\\d\\d)?$"),
-            case(vec!["890", "34"], "^\\d\\d(?:\\d)?$"),
-            case(vec!["abc123"], "^abc\\d\\d\\d$"),
-            case(vec!["a1b2c3"], "^a\\db\\dc\\d$"),
-            case(vec!["abc", "123"], "^(?:\\d\\d\\d|abc)$"),
-            case(vec!["١", "٣", "٥"], "^\\d$"), // Arabic digits: ١ = 1, ٣ = 3, ٥ = 5
-            case(vec!["١٣٥"], "^\\d\\d\\d$"),
-            case(vec!["a٣3", "b5٥"], "^[ab]\\d\\d$"),
-            case(vec!["I ♥ 123"], "^I ♥ \\d\\d\\d$"),
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^I   ♥♥♥ \\d\\d and \\d and y̆y̆ and 💩💩\\.$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec![""], ""),
+          case(vec!["a"], "a"),
+          case(vec!["1"], "\\d"),
+          case(vec!["-1"], "\\-\\d"),
+          case(vec!["12"], "\\d\\d"),
+          case(vec!["1", "2"], "\\d"),
+          case(vec!["1", "23"], "\\d(?:\\d)?"),
+          case(vec!["1", "234"], "\\d(?:\\d\\d)?"),
+          case(vec!["8", "234"], "\\d(?:\\d\\d)?"),
+          case(vec!["890", "34"], "\\d\\d(?:\\d)?"),
+          case(vec!["abc123"], "abc\\d\\d\\d"),
+          case(vec!["a1b2c3"], "a\\db\\dc\\d"),
+          case(vec!["abc", "123"], "(?:\\d\\d\\d|abc)"),
+          case(vec!["١", "٣", "٥"], "\\d"), // Arabic digits: ١ = 1, ٣ = 3, ٥ = 5
+          case(vec!["١٣٥"], "\\d\\d\\d"),
+          case(vec!["a٣3", "b5٥"], "[ab]\\d\\d"),
+          case(vec!["I ♥ 123"], "I ♥ \\d\\d\\d"),
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "I   ♥♥♥ \\d\\d and \\d and y̆y̆ and 💩💩\\.")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I   \\u{2665}\\u{2665}\\u{2665} \\d\\d and \\d and y\\u{306}y\\u{306} and \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I {3}♥{3} \\d(?:\\d and ){2}(?:y̆){2} and 💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I {3}♥{3} \\d(?:\\d and ){2}(?:y̆){2} and 💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and \\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and \\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I {3}\\u{2665}{3} \\d(?:\\d and ){2}(?:y\\u{306}){2} and (?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["1"], "^\\d$"),
-            case(vec!["12"], "^\\d\\d$"),
-            case(vec!["123"], "^\\d{3}$"),
-            case(vec!["1", "12", "123"], "^(?:\\d\\d|\\d|\\d{3})$"),
-            case(vec!["12", "123", "1234"], "^(?:\\d\\d|\\d{3,4})$"),
-            case(vec!["123", "1234", "12345"], "^\\d{3,5}$"),
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^I {3}♥{3} \\d\\d and \\d and y̆y̆ and 💩💩\\.$")
-        )]
-        fn succeeds_with_increased_minimum_repetitions(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit])
-                .with_minimum_repetitions(2)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["1"], "\\d"),
+          case(vec!["12"], "\\d\\d"),
+          case(vec!["123"], "\\d{3}"),
+          case(vec!["1", "12", "123"], "(?:\\d\\d|\\d|\\d{3})"),
+          case(vec!["12", "123", "1234"], "(?:\\d\\d|\\d{3,4})"),
+          case(vec!["123", "1234", "12345"], "\\d{3,5}"),
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "I {3}♥{3} \\d\\d and \\d and y̆y̆ and 💩💩\\.")
+      )]
+      fn succeeds_with_increased_minimum_repetitions(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit])
+              .with_minimum_repetitions(2)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod space_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec![" "], "^\\s$"),
-            case(vec!["   "], "^\\s\\s\\s$"),
-            case(vec!["\n"], "^\\s$"),
-            case(vec!["\u{c}"], "^\\s$"), // form feed \f
-            case(vec!["\u{b}"], "^\\s$"), // vertical tab \v
-            case(vec!["\n", "\r"], "^\\s$"),
-            case(vec!["\n\t", "\r"], "^\\s(?:\\s)?$"),
-            case(vec!["a"], "^a$"),
-            case(vec!["1"], "^1$"),
-            case(vec!["I ♥ 123"], "^I\\s♥\\s123$"),
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^I\\s\\s\\s♥♥♥\\s36\\sand\\s٣\\sand\\sy̆y̆\\sand\\s💩💩\\.$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec![""], ""),
+          case(vec![" "], "\\s"),
+          case(vec!["   "], "\\s\\s\\s"),
+          case(vec!["\n"], "\\s"),
+          case(vec!["\u{c}"], "\\s"), // form feed \f
+          case(vec!["\u{b}"], "\\s"), // vertical tab \v
+          case(vec!["\n", "\r"], "\\s"),
+          case(vec!["\n\t", "\r"], "\\s(?:\\s)?"),
+          case(vec!["a"], "a"),
+          case(vec!["1"], "1"),
+          case(vec!["I ♥ 123"], "I\\s♥\\s123"),
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "I\\s\\s\\s♥♥♥\\s36\\sand\\s٣\\sand\\sy̆y̆\\sand\\s💩💩\\.")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s36\\sand\\s\\u{663}\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\s(?:y̆){2}\\sand\\s💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\s(?:y̆){2}\\sand\\s💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}\\u{2665}{3}\\s36\\sand\\s\\u{663}\\sand\\s(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec![" "], "^\\s$"),
-            case(vec!["  "], "^\\s\\s$"),
-            case(vec!["   "], "^\\s{3}$"),
-            case(vec![" ", "  ", "   "], "^(?:\\s\\s|\\s|\\s{3})$"),
-            case(vec!["  ", "   ", "    "], "^(?:\\s\\s|\\s{3,4})$"),
-            case(vec!["   ", "    ", "     "], "^\\s{3,5}$"),
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\sy\u{306}y\u{306}\\sand\\s💩💩\\.$"
-            )
-        )]
-        fn succeeds_with_increased_minimum_repetitions(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space])
-                .with_minimum_repetitions(2)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec![" "], "\\s"),
+          case(vec!["  "], "\\s\\s"),
+          case(vec!["   "], "\\s{3}"),
+          case(vec![" ", "  ", "   "], "(?:\\s\\s|\\s|\\s{3})"),
+          case(vec!["  ", "   ", "    "], "(?:\\s\\s|\\s{3,4})"),
+          case(vec!["   ", "    ", "     "], "\\s{3,5}"),
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}♥{3}\\s36\\sand\\s٣\\sand\\sy\u{306}y\u{306}\\sand\\s💩💩\\."
+          )
+      )]
+      fn succeeds_with_increased_minimum_repetitions(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space])
+              .with_minimum_repetitions(2)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec![""], "^$"),
-            case(vec![" "], "^ $"),
-            case(vec!["a"], "^\\w$"),
-            case(vec!["1"], "^\\w$"),
-            case(vec!["-1"], "^\\-\\w$"),
-            case(vec!["1", "2"], "^\\w$"),
-            case(vec!["ä", "ß"], "^\\w$"),
-            case(vec!["abc", "1234"], "^\\w\\w\\w(?:\\w)?$"),
-            case(vec!["١", "٣", "٥"], "^\\w$"), // Arabic digits: ١ = 1, ٣ = 3, ٥ = 5
-            case(vec!["١٣٥"], "^\\w\\w\\w$"),
-            case(vec!["a٣3", "b5٥"], "^\\w\\w\\w$"),
-            case(vec!["I ♥ 123"], "^\\w ♥ \\w\\w\\w$"),
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   ♥♥♥ \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec![""], ""),
+          case(vec![" "], " "),
+          case(vec!["a"], "\\w"),
+          case(vec!["1"], "\\w"),
+          case(vec!["-1"], "\\-\\w"),
+          case(vec!["1", "2"], "\\w"),
+          case(vec!["ä", "ß"], "\\w"),
+          case(vec!["abc", "1234"], "\\w\\w\\w(?:\\w)?"),
+          case(vec!["١", "٣", "٥"], "\\w"), // Arabic digits: ١ = 1, ٣ = 3, ٥ = 5
+          case(vec!["١٣٥"], "\\w\\w\\w"),
+          case(vec!["a٣3", "b5٥"], "\\w\\w\\w"),
+          case(vec!["I ♥ 123"], "\\w ♥ \\w\\w\\w"),
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   ♥♥♥ \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   \\u{2665}\\u{2665}\\u{2665} \\w\\w \\w\\w\\w \\w \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}♥{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}♥{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} \\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} \\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}\\u{2665}{3} \\w{2} \\w{3} \\w \\w{3} \\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["a"], "^\\w$"),
-            case(vec!["ab"], "^\\w\\w$"),
-            case(vec!["abc"], "^\\w{3}$"),
-            case(vec!["a", "ab", "abc"], "^(?:\\w\\w|\\w|\\w{3})$"),
-            case(vec!["ab", "abc", "abcd"], "^(?:\\w\\w|\\w{3,4})$"),
-            case(vec!["abc", "abcd", "abcde"], "^\\w{3,5}$"),
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}♥{3} \\w\\w \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩💩\\.$"
-            )
-        )]
-        fn succeeds_with_increased_minimum_repetitions(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Word])
-                .with_minimum_repetitions(2)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["a"], "\\w"),
+          case(vec!["ab"], "\\w\\w"),
+          case(vec!["abc"], "\\w{3}"),
+          case(vec!["a", "ab", "abc"], "(?:\\w\\w|\\w|\\w{3})"),
+          case(vec!["ab", "abc", "abcd"], "(?:\\w\\w|\\w{3,4})"),
+          case(vec!["abc", "abcd", "abcde"], "\\w{3,5}"),
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}♥{3} \\w\\w \\w{3} \\w \\w{3} \\w{4} \\w{3} 💩💩\\."
+          )
+      )]
+      fn succeeds_with_increased_minimum_repetitions(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Word])
+              .with_minimum_repetitions(2)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod digit_space_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s\\s\\s♥♥♥\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s\\s\\s♥♥♥\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\sand\\s\\d\\sand\\sy\\u{306}y\\u{306}\\sand\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}♥{3}\\s\\d(?:\\d\\sand\\s){2}(?:y̆){2}\\sand\\s💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}♥{3}\\s\\d(?:\\d\\sand\\s){2}(?:y̆){2}\\sand\\s💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s\\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\sand\\s){2}(?:y\\u{306}){2}\\sand\\s(?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["1\n"], "^\\d\\s$"),
-            case(vec!["1\n1\n"], "^\\d\\s\\d\\s$"),
-            case(vec!["1\n1\n1\n"], "^(?:\\d\\s){3}$"),
-            case(vec!["1\n", "1\n1\n", "1\n1\n1\n"], "^(?:\\d\\s\\d\\s|\\d\\s|(?:\\d\\s){3})$"),
-            case(vec!["1\n1\n", "1\n1\n1\n", "1\n1\n1\n1\n"], "^(?:\\d\\s\\d\\s|(?:\\d\\s){3,4})$"),
-            case(vec!["1\n1\n1\n", "1\n1\n1\n1\n", "1\n1\n1\n1\n1\n"], "^(?:\\d\\s){3,5}$"),
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\s{3}♥{3}\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\.$"
-            )
-        )]
-        fn succeeds_with_increased_minimum_repetitions(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
-                .with_minimum_repetitions(2)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec!["1\n"], "\\d\\s"),
+          case(vec!["1\n1\n"], "\\d\\s\\d\\s"),
+          case(vec!["1\n1\n1\n"], "(?:\\d\\s){3}"),
+          case(vec!["1\n", "1\n1\n", "1\n1\n1\n"], "(?:\\d\\s\\d\\s|\\d\\s|(?:\\d\\s){3})"),
+          case(vec!["1\n1\n", "1\n1\n1\n", "1\n1\n1\n1\n"], "(?:\\d\\s\\d\\s|(?:\\d\\s){3,4})"),
+          case(vec!["1\n1\n1\n", "1\n1\n1\n1\n", "1\n1\n1\n1\n1\n"], "(?:\\d\\s){3,5}"),
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\s{3}♥{3}\\s\\d\\d\\sand\\s\\d\\sand\\sy̆y̆\\sand\\s💩💩\\."
+          )
+      )]
+      fn succeeds_with_increased_minimum_repetitions(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Space])
+              .with_minimum_repetitions(2)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["1\n1\n"], "^1\\n1\\n$"),
-            case(vec!["1\n\n1\n\n"], "^(?:1\\n\\n){2}$")
-        )]
-        fn succeeds_with_increased_minimum_substring_length(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_minimum_substring_length(3)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec!["1\n1\n"], "1\\n1\\n"),
+          case(vec!["1\n\n1\n\n"], "(?:1\\n\\n){2}")
+      )]
+      fn succeeds_with_increased_minimum_substring_length(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_minimum_substring_length(3)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["1\n1\n"], "^1\\n1\\n$"),
-            case(vec!["1\n1\n1\n"], "^1\\n1\\n1\\n$"),
-            case(vec!["1\n\n1\n\n"], "^1\\n\\n1\\n\\n$"),
-            case(vec!["1\n\n1\n\n1\n\n"], "^(?:1\\n\\n){3}$")
-        )]
-        fn succeeds_with_increased_minimum_repetitions_and_substring_length(
-            test_cases: Vec<&str>,
-            expected_output: &str,
-        ) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition])
-                .with_minimum_repetitions(2)
-                .with_minimum_substring_length(3)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["1\n1\n"], "1\\n1\\n"),
+          case(vec!["1\n1\n1\n"], "1\\n1\\n1\\n"),
+          case(vec!["1\n\n1\n\n"], "1\\n\\n1\\n\\n"),
+          case(vec!["1\n\n1\n\n1\n\n"], "(?:1\\n\\n){3}")
+      )]
+      fn succeeds_with_increased_minimum_repetitions_and_substring_length(
+          test_cases: Vec<&str>,
+          expected_output: &str,
+      ) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition])
+              .with_minimum_repetitions(2)
+              .with_minimum_substring_length(3)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod digit_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   ♥♥♥ \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   ♥♥♥ \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w 💩💩\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w   \\u{2665}\\u{2665}\\u{2665} \\d\\d \\w\\w\\w \\d \\w\\w\\w \\w\\w\\w\\w \\w\\w\\w \\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}♥{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} 💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}♥{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} 💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} \\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} \\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w {3}\\u{2665}{3} \\d(?:\\d \\w{3} ){2}\\w{4} \\w{3} (?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 }
 
 mod space_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s♥♥♥\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s♥♥♥\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\w\\w\\s\\w\\w\\w\\s\\w\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}♥{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}♥{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}\\u{2665}{3}\\s\\w{2}\\s\\w{3}\\s\\w\\s\\w{3}\\s\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 }
 
 mod digit_space_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s♥♥♥\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s♥♥♥\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s💩💩\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{1f4a9}\\u{1f4a9}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s\\s\\s\\u{2665}\\u{2665}\\u{2665}\\s\\d\\d\\s\\w\\w\\w\\s\\d\\s\\w\\w\\w\\s\\w\\w\\w\\w\\s\\w\\w\\w\\s\\u{d83d}\\u{dca9}\\u{d83d}\\u{dca9}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::Space, Feature::Word])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}♥{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s💩{2}\\.$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[
-                    Feature::Repetition,
-                    Feature::Digit,
-                    Feature::Space,
-                    Feature::Word,
-                ])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}♥{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s💩{2}\\."
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[
+                  Feature::Repetition,
+                  Feature::Digit,
+                  Feature::Space,
+                  Feature::Word,
+              ])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[
-                    Feature::Repetition,
-                    Feature::Digit,
-                    Feature::Space,
-                    Feature::Word,
-                ])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s\\u{1f4a9}{2}\\."
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[
+                  Feature::Repetition,
+                  Feature::Digit,
+                  Feature::Space,
+                  Feature::Word,
+              ])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\.$"
-            )
-        )]
-        fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[
-                    Feature::Repetition,
-                    Feature::Digit,
-                    Feature::Space,
-                    Feature::Word,
-                ])
-                .with_escaping_of_non_ascii_chars(true)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\s{3}\\u{2665}{3}\\s\\d(?:\\d\\s\\w{3}\\s){2}\\w{4}\\s\\w{3}\\s(?:\\u{d83d}\\u{dca9}){2}\\."
+          )
+      )]
+      fn succeeds_with_escape_and_surrogate_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[
+                  Feature::Repetition,
+                  Feature::Digit,
+                  Feature::Space,
+                  Feature::Word,
+              ])
+              .with_escaping_of_non_ascii_chars(true)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+      }
+  }
 }
 
 mod non_digit_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonDigit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonDigit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonDigit])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D\\u{663}\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonDigit])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}36\\D{5}٣\\D{17}$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonDigit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}36\\D{5}٣\\D{17}")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonDigit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}36\\D{5}\\u{663}\\D{17}$")
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonDigit])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}36\\D{5}\\u{663}\\D{17}")
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonDigit])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_space_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S   \\S\\S\\S \\S\\S \\S\\S\\S \\S \\S\\S\\S \\S\\S\\S\\S \\S\\S\\S \\S\\S\\S"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S {3}\\S{3} \\S{2} \\S{3} \\S \\S{3} \\S{4} \\S{3} \\S{3}"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W٣\\Wand\\Wy̆y̆\\Wand\\W\\W\\W\\W$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W٣\\Wand\\Wy̆y̆\\Wand\\W\\W\\W\\W"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonWord])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\W\\W\\W\\W\\W\\W\\W36\\Wand\\W\\u{663}\\Wand\\Wy\\u{306}y\\u{306}\\Wand\\W\\W\\W\\W"
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonWord])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\W{7}36\\Wand\\W٣\\Wand\\W(?:y̆){2}\\Wand\\W{4}$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\W{7}36\\Wand\\W٣\\Wand\\W(?:y̆){2}\\Wand\\W{4}"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}$"
-            )
-        )]
-        fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonWord])
-                .with_escaping_of_non_ascii_chars(false)
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "I\\W{7}36\\Wand\\W\\u{663}\\Wand\\W(?:y\\u{306}){2}\\Wand\\W{4}"
+          )
+      )]
+      fn succeeds_with_escape_option(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonWord])
+              .with_escaping_of_non_ascii_chars(false)
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_digit_non_space_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonDigit, Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonDigit, Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}\\S{2}\\D{5}\\S\\D{17}$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonDigit, Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}\\S{2}\\D{5}\\S\\D{17}")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonDigit, Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_digit_non_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonDigit, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D36\\D\\D\\D\\D\\D٣\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonDigit, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}36\\D{5}٣\\D{17}$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonDigit, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}36\\D{5}٣\\D{17}")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonDigit, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_space_non_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonSpace, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S\\W\\W\\W\\W\\W\\W\\W\\S\\S\\W\\S\\S\\S\\W\\S\\W\\S\\S\\S\\W\\S\\S\\S\\S\\W\\S\\S\\S\\W\\W\\W\\W"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonSpace, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::NonSpace, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S\\W{7}\\S{2}\\W\\S{3}\\W\\S\\W\\S{3}\\W\\S{4}\\W\\S{3}\\W{4}"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::NonSpace, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod non_digit_non_space_non_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::NonDigit, Feature::NonSpace, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D\\S\\S\\D\\D\\D\\D\\D\\S\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::NonDigit, Feature::NonSpace, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}\\S{2}\\D{5}\\S\\D{17}$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[
-                    Feature::Repetition,
-                    Feature::NonDigit,
-                    Feature::NonSpace,
-                    Feature::NonWord,
-                ])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}\\S{2}\\D{5}\\S\\D{17}")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[
+                  Feature::Repetition,
+                  Feature::NonDigit,
+                  Feature::NonSpace,
+                  Feature::NonWord,
+              ])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod digit_non_digit_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Digit, Feature::NonDigit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\D\\D\\D\\D\\D\\D\\D\\D\\d\\d\\D\\D\\D\\D\\D\\d\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D\\D"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Digit, Feature::NonDigit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "^\\D{8}\\d{2}\\D{5}\\d\\D{17}$")
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::NonDigit])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."], "\\D{8}\\d{2}\\D{5}\\d\\D{17}")
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Digit, Feature::NonDigit])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod space_non_space_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Space, Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S\\s\\s\\s\\S\\S\\S\\s\\S\\S\\s\\S\\S\\S\\s\\S\\s\\S\\S\\S\\s\\S\\S\\S\\S\\s\\S\\S\\S\\s\\S\\S\\S"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Space, Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::NonSpace])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\S\\s{3}\\S{3}\\s\\S{2}\\s\\S{3}\\s\\S\\s\\S{3}\\s\\S{4}\\s\\S{3}\\s\\S{3}"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Space, Feature::NonSpace])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 mod word_non_word_conversion {
-    use super::*;
+  use super::*;
 
-    mod no_repetition {
-        use super::*;
+  mod no_repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Word, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\W\\W\\W\\W\\W\\W\\W\\w\\w\\W\\w\\w\\w\\W\\w\\W\\w\\w\\w\\W\\w\\w\\w\\w\\W\\w\\w\\w\\W\\W\\W\\W"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Word, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 
-    mod repetition {
-        use super::*;
+  mod repetition {
+      use super::*;
 
-        #[rstest(test_cases, expected_output,
-            case(
-                vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
-                "^\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}$"
-            )
-        )]
-        fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
-            let regexp = RegExpBuilder::from(&test_cases)
-                .with_conversion_of(&[Feature::Repetition, Feature::Word, Feature::NonWord])
-                .build();
-            assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
-            assert_that_regexp_matches_test_cases(expected_output, test_cases);
-        }
-    }
+      #[rstest(test_cases, expected_output,
+          case(
+              vec!["I   ♥♥♥ 36 and ٣ and y̆y̆ and 💩💩."],
+              "\\w\\W{7}\\w{2}\\W\\w{3}\\W\\w\\W\\w{3}\\W\\w{4}\\W\\w{3}\\W{4}"
+          )
+      )]
+      fn succeeds(test_cases: Vec<&str>, expected_output: &str) {
+          let regexp = RegExpBuilder::from(&test_cases)
+              .with_conversion_of(&[Feature::Repetition, Feature::Word, Feature::NonWord])
+              .build();
+          assert_that_regexp_is_correct(regexp, expected_output, &test_cases);
+          assert_that_regexp_matches_test_cases(expected_output, test_cases);
+      }
+  }
 }
 
 fn assert_that_regexp_is_correct(regexp: String, expected_output: &str, test_cases: &[&str]) {
-    assert_eq!(
-        regexp, expected_output,
-        "\n\ninput: {:?}\nexpected: {}\nactual: {}\n\n",
-        test_cases, expected_output, regexp
-    );
+  assert_eq!(
+      regexp, expected_output,
+      "\n\ninput: {:?}\nexpected: {}\nactual: {}\n\n",
+      test_cases, expected_output, regexp
+  );
 }
 
 fn assert_that_regexp_matches_test_cases(expected_output: &str, test_cases: Vec<&str>) {
-    let re = Regex::new(expected_output).unwrap();
-    for test_case in test_cases {
-        assert!(
-            re.is_match(test_case),
-            "\n\n\"{}\" does not match regex {}\n\n",
-            test_case,
-            expected_output
-        );
-    }
+  let re = Regex::new(expected_output).unwrap();
+  for test_case in test_cases {
+      assert!(
+          re.is_match(test_case),
+          "\n\n\"{}\" does not match regex {}\n\n",
+          test_case,
+          expected_output
+      );
+  }
 }


### PR DESCRIPTION
Additional options:
`-B`, `--match-beginning` - Match the beginning of the string (prepend `^`)
`-E`, `--match-end` - Match the end of the string (append `$`)
`-X`, `--match-line` - Match the whole string (as a shorthand for `-B -E`)

It's result of the discussion in the issue pemistahl/grex#30. 
Sorry, if some of my modifications look silly. It's my attempt to understand Rust from the scratch. 
