### PR TITLE
applied clippy recommendations

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -441,8 +441,8 @@ impl Expression {
         b: &Expression,
         substring: &Substring,
     ) -> Option<Vec<Grapheme>> {
-        let mut graphemes_a = a.value(Some(substring)).unwrap_or_else(Vec::new);
-        let mut graphemes_b = b.value(Some(substring)).unwrap_or_else(Vec::new);
+        let mut graphemes_a = a.value(Some(substring)).unwrap_or_default();
+        let mut graphemes_b = b.value(Some(substring)).unwrap_or_default();
         let mut common_graphemes = vec![];
 
         if let Substring::Suffix = substring {

--- a/src/char/grapheme.rs
+++ b/src/char/grapheme.rs
@@ -124,9 +124,9 @@ impl Grapheme {
             }
 
             character = character
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
+                .replace('\n', "\\n")
+                .replace('\r', "\\r")
+                .replace('\t', "\\t");
 
             if character == "\\" {
                 character = "\\\\".to_string();

--- a/src/fsm/dfa.rs
+++ b/src/fsm/dfa.rs
@@ -281,7 +281,7 @@ mod tests {
     fn test_is_final_state() {
         let config = RegExpConfig::new();
         let dfa = Dfa::from(
-            &vec![GraphemeCluster::from("abcd", &RegExpConfig::new())],
+            &[GraphemeCluster::from("abcd", &RegExpConfig::new())],
             true,
             &config,
         );
@@ -297,10 +297,8 @@ mod tests {
     fn test_outgoing_edges() {
         let config = RegExpConfig::new();
         let dfa = Dfa::from(
-            &vec![
-                GraphemeCluster::from("abcd", &RegExpConfig::new()),
-                GraphemeCluster::from("abxd", &RegExpConfig::new()),
-            ],
+            &[GraphemeCluster::from("abcd", &RegExpConfig::new()),
+                GraphemeCluster::from("abxd", &RegExpConfig::new())],
             true,
             &config,
         );
@@ -329,10 +327,8 @@ mod tests {
     fn test_states_in_depth_first_order() {
         let config = RegExpConfig::new();
         let dfa = Dfa::from(
-            &vec![
-                GraphemeCluster::from("abcd", &RegExpConfig::new()),
-                GraphemeCluster::from("axyz", &RegExpConfig::new()),
-            ],
+            &[GraphemeCluster::from("abcd", &RegExpConfig::new()),
+                GraphemeCluster::from("axyz", &RegExpConfig::new())],
             true,
             &config,
         );
@@ -420,10 +416,8 @@ mod tests {
     fn test_dfa_constructor() {
         let config = RegExpConfig::new();
         let dfa = Dfa::from(
-            &vec![
-                GraphemeCluster::from("abcd", &RegExpConfig::new()),
-                GraphemeCluster::from("abxd", &RegExpConfig::new()),
-            ],
+            &[GraphemeCluster::from("abcd", &RegExpConfig::new()),
+                GraphemeCluster::from("abxd", &RegExpConfig::new())],
             true,
             &config,
         );

--- a/src/regexp/component.rs
+++ b/src/regexp/component.rs
@@ -147,7 +147,7 @@ impl Display for Component {
                 Component::CapturedParenthesizedExpression(expr) => format!(
                     "{}{}{}",
                     Component::CapturedLeftParenthesis,
-                    expr.to_string(),
+                    expr,
                     Component::RightParenthesis
                 ),
                 Component::Caret => "^".to_string(),

--- a/src/regexp/regexp.rs
+++ b/src/regexp/regexp.rs
@@ -161,14 +161,14 @@ impl Display for RegExp {
                     "{}{}{}{}",
                     ignore_case_flag,
                     caret,
-                    self.ast.to_string(),
+                    self.ast,
                     dollar_sign
                 )
             }
         };
 
         if regexp.contains('\u{b}') {
-            regexp = regexp.replace("\u{b}", "\\v"); // U+000B Line Tabulation
+            regexp = regexp.replace('\u{b}', "\\v"); // U+000B Line Tabulation
         }
 
         write!(
@@ -300,35 +300,35 @@ fn apply_verbose_mode(regexp: String, config: &RegExpConfig) -> String {
             &Component::IgnoreCaseFlag.to_repr(config.is_output_colorized),
             "",
         )
-        .replace("#", "\\#")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace(" ", "\\s")
-        .replace("\u{85}", "\\s")
-        .replace("\u{a0}", "\\s")
-        .replace("\u{1680}", "\\s")
-        .replace("\u{2000}", "\\s")
-        .replace("\u{2001}", "\\s")
-        .replace("\u{2002}", "\\s")
-        .replace("\u{2003}", "\\s")
-        .replace("\u{2004}", "\\s")
-        .replace("\u{2005}", "\\s")
-        .replace("\u{2006}", "\\s")
-        .replace("\u{2007}", "\\s")
-        .replace("\u{2008}", "\\s")
-        .replace("\u{2009}", "\\s")
-        .replace("\u{200a}", "\\s")
-        .replace("\u{200b}", "\\s")
-        .replace("\u{2028}", "\\s")
-        .replace("\u{2029}", "\\s")
-        .replace("\u{202f}", "\\s")
-        .replace("\u{205f}", "\\s")
-        .replace("\u{3000}", "\\s")
-        .replace(" ", "\\ ");
+        .replace('#', "\\#")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace(' ', "\\s")
+        .replace('\u{85}', "\\s")
+        .replace('\u{a0}', "\\s")
+        .replace('\u{1680}', "\\s")
+        .replace('\u{2000}', "\\s")
+        .replace('\u{2001}', "\\s")
+        .replace('\u{2002}', "\\s")
+        .replace('\u{2003}', "\\s")
+        .replace('\u{2004}', "\\s")
+        .replace('\u{2005}', "\\s")
+        .replace('\u{2006}', "\\s")
+        .replace('\u{2007}', "\\s")
+        .replace('\u{2008}', "\\s")
+        .replace('\u{2009}', "\\s")
+        .replace('\u{200a}', "\\s")
+        .replace('\u{200b}', "\\s")
+        .replace('\u{2028}', "\\s")
+        .replace('\u{2029}', "\\s")
+        .replace('\u{202f}', "\\s")
+        .replace('\u{205f}', "\\s")
+        .replace('\u{3000}', "\\s")
+        .replace(' ', "\\ ");
 
     if config.is_output_colorized {
         for regexp_match in COLOR_MODE_REGEX.find_iter(&regexp_with_replacements) {

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -123,7 +123,7 @@ proptest! {
         let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
         let regexp = RegExpBuilder::from(&test_cases_vec).build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -136,7 +136,7 @@ proptest! {
             .with_escaping_of_non_ascii_chars(false)
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -149,7 +149,7 @@ proptest! {
             .with_verbose_mode()
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -163,7 +163,7 @@ proptest! {
             .with_verbose_mode()
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -181,7 +181,7 @@ proptest! {
             .with_minimum_substring_length(minimum_substring_length)
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -200,7 +200,7 @@ proptest! {
             .with_escaping_of_non_ascii_chars(false)
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -219,7 +219,7 @@ proptest! {
             .with_verbose_mode()
             .build();
         if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(&test_case)));
+            prop_assert!(test_cases.iter().all(|test_case| compiled_regexp.is_match(test_case)));
         }
     }
 
@@ -298,7 +298,7 @@ proptest! {
             let test_cases_vec = test_cases.iter().cloned().collect::<Vec<_>>();
             let regexp = RegExpBuilder::from(&test_cases_vec).build();
             if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-                prop_assert!(other_strings.iter().all(|other_string| !compiled_regexp.is_match(&other_string)));
+                prop_assert!(other_strings.iter().all(|other_string| !compiled_regexp.is_match(other_string)));
             }
         }
     }
@@ -314,7 +314,7 @@ proptest! {
                 .with_escaping_of_non_ascii_chars(false)
                 .build();
             if let Ok(compiled_regexp) = compile_regexp(&regexp) {
-                prop_assert!(other_strings.iter().all(|other_string| !compiled_regexp.is_match(&other_string)));
+                prop_assert!(other_strings.iter().all(|other_string| !compiled_regexp.is_match(other_string)));
             }
         }
     }


### PR DESCRIPTION
for the following:
```
warning: use of `.unwrap_or_else(..)` to construct default value
   --> src\ast\expression.rs:444:31
    |
444 |         let mut graphemes_a = a.value(Some(substring)).unwrap_or_else(Vec::new);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.value(Some(substring)).unwrap_or_default()`
    |
    = note: `#[warn(clippy::unwrap_or_else_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default

warning: use of `.unwrap_or_else(..)` to construct default value
   --> src\ast\expression.rs:445:31
    |
445 |         let mut graphemes_b = b.value(Some(substring)).unwrap_or_else(Vec::new);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b.value(Some(substring)).unwrap_or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default

warning: single-character string constant used as pattern
   --> src\char\grapheme.rs:129:26
    |
129 |                 .replace("\t", "\\t");
    |                          ^^^^ help: try using a `char` instead: `'\t'`
    |
    = note: `#[warn(clippy::single_char_pattern)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\char\grapheme.rs:128:26
    |
128 |                 .replace("\r", "\\r")
    |                          ^^^^ help: try using a `char` instead: `'\r'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\char\grapheme.rs:127:26
    |
127 |                 .replace("\n", "\\n")
    |                          ^^^^ help: try using a `char` instead: `'\n'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: `to_string` applied to a type that implements `Display` in `format!` args
   --> src\regexp\component.rs:150:25
    |
150 |                     expr.to_string(),
    |                         ^^^^^^^^^^^^ help: remove this
    |
    = note: `#[warn(clippy::to_string_in_format_args)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args

warning: `to_string` applied to a type that implements `Display` in `format!` args
   --> src\regexp\regexp.rs:164:29
    |
164 |                     self.ast.to_string(),
    |                             ^^^^^^^^^^^^ help: remove this
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:171:37
    |
171 |             regexp = regexp.replace("\u{b}", "\\v"); // U+000B Line Tabulation
    |                                     ^^^^^^^ help: try using a `char` instead: `'\u{b}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:331:18
    |
331 |         .replace(" ", "\\ ");
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:330:18
    |
330 |         .replace("\u{3000}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{3000}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:329:18
    |
329 |         .replace("\u{205f}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{205f}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:328:18
    |
328 |         .replace("\u{202f}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{202f}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:327:18
    |
327 |         .replace("\u{2029}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2029}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:326:18
    |
326 |         .replace("\u{2028}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2028}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:325:18
    |
325 |         .replace("\u{200b}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{200b}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:324:18
    |
324 |         .replace("\u{200a}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{200a}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:323:18
    |
323 |         .replace("\u{2009}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2009}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:322:18
    |
322 |         .replace("\u{2008}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2008}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:321:18
    |
321 |         .replace("\u{2007}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2007}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:320:18
    |
320 |         .replace("\u{2006}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2006}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:319:18
    |
319 |         .replace("\u{2005}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2005}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:318:18
    |
318 |         .replace("\u{2004}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2004}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:317:18
    |
317 |         .replace("\u{2003}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2003}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:316:18
    |
316 |         .replace("\u{2002}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2002}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:315:18
    |
315 |         .replace("\u{2001}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2001}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:314:18
    |
314 |         .replace("\u{2000}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{2000}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:313:18
    |
313 |         .replace("\u{1680}", "\\s")
    |                  ^^^^^^^^^^ help: try using a `char` instead: `'\u{1680}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:312:18
    |
312 |         .replace("\u{a0}", "\\s")
    |                  ^^^^^^^^ help: try using a `char` instead: `'\u{a0}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:311:18
    |
311 |         .replace("\u{85}", "\\s")
    |                  ^^^^^^^^ help: try using a `char` instead: `'\u{85}'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:310:18
    |
310 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:309:18
    |
309 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:308:18
    |
308 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:307:18
    |
307 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:306:18
    |
306 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:305:18
    |
305 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:304:18
    |
304 |         .replace(" ", "\\s")
    |                  ^^^ help: try using a `char` instead: `' '`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
   --> src\regexp\regexp.rs:303:18
    |
303 |         .replace("#", "\\#")
    |                  ^^^ help: try using a `char` instead: `'#'`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: `grex` (lib) generated 37 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 14.32s
```